### PR TITLE
add PDO storage support for refresh tokens

### DIFF
--- a/src/OAuth2/Storage/Pdo.php
+++ b/src/OAuth2/Storage/Pdo.php
@@ -161,7 +161,9 @@ class OAuth2_Storage_Pdo implements OAuth2_Storage_AuthorizationCodeInterface,
 
     public function unsetRefreshToken($refresh_token)
     {
-        unset($this->refreshTokens[$refresh_token]);
+        $stmt = $this->db->prepare(sprintf('DELETE FROM %s WHERE refresh_token = "%s"', $this->config['refresh_token_table'], $refresh_token));
+
+        return $stmt->execute();
     }
 
     public function setRefreshTokens($refresh_tokens)


### PR DESCRIPTION
- Included OAuth2_Storage_RefreshTokenInterface and functions for PDO
  support of refresh_tokens
- Renamed table vars in config array

Resubmitting with only the refresh token addition. Figured out the Travis-Cl stuff (neat!) and it passed.
