### PR TITLE
Store authorization header for type Bearer

### DIFF
--- a/src/OAuth2/Request.php
+++ b/src/OAuth2/Request.php
@@ -156,10 +156,16 @@ class OAuth2_Request implements OAuth2_RequestInterface
             }
 
             // Decode AUTHORIZATION header into PHP_AUTH_USER and PHP_AUTH_PW when authorization header is basic
-            if ((null !== $authorizationHeader) && (0 === stripos($authorizationHeader, 'basic'))) {
-                $exploded = explode(':', base64_decode(substr($authorizationHeader, 6)));
-                if (count($exploded) == 2) {
-                    list($headers['PHP_AUTH_USER'], $headers['PHP_AUTH_PW']) = $exploded;
+            if (null !== $authorizationHeader) {
+                if (0 === stripos($authorizationHeader, 'basic')) {
+                    $exploded = explode(':', base64_decode(substr($authorizationHeader, 6)));
+                    if (count($exploded) == 2) {
+                        list($headers['PHP_AUTH_USER'], $headers['PHP_AUTH_PW']) = $exploded;
+                    }
+                }
+                // Store AUTHORIZATION header when authorization header is bearer
+                if (0 === stripos($authorizationHeader, 'bearer')) {
+                    $headers['AUTHORIZATION'] = $authorizationHeader;
                 }
             }
         }


### PR DESCRIPTION
When "Basic" Authorization is provided, getHeadersFromServer() populates
globals for use in verifying an OAuth client. When "Bearer"
Authorization is provided, nothing is populated.

This captures the authorization header when "Bearer" Authorization is
provided, which can be used in verifying an access_token per
http://tools.ietf.org/html/rfc6750#section-2.1
