### PR TITLE
Fix for getRefreshToken() in Pdo.php

### DIFF
--- a/src/OAuth2/Storage/Pdo.php
+++ b/src/OAuth2/Storage/Pdo.php
@@ -129,7 +129,7 @@ class OAuth2_Storage_Pdo implements OAuth2_Storage_AuthorizationCodeInterface,
 
     public function expireAuthorizationCode($code)
     {
-        $stmt = $this->db->prepare(sprintf('DELETE FROM %s WHERE authorization_code = :authorization_code', $this->config['code_table']));
+        $stmt = $this->db->prepare(sprintf('DELETE FROM %s WHERE authorization_code = :code', $this->config['code_table']));
 
         return $stmt->execute(compact('code'));
     }


### PR DESCRIPTION
Fix for 'PDOStatement::execute() expects parameter 1 to be array, string
given' introduced by line 148 in commit
97bdd2ca13ae03415982cdab8965dc605b4882be
