### PR TITLE
Serve `application/json` headers without send()

### DIFF
--- a/src/OAuth2/Response.php
+++ b/src/OAuth2/Response.php
@@ -137,14 +137,23 @@ class OAuth2_Response
         $this->httpHeaders[$name] = $value;
     }
 
-    public function getHttpHeaders()
+    public function getHttpHeaders($format = 'json')
     {
+        switch ($format) {
+            case 'json':
+                $this->setHttpHeader('Content-Type', 'application/json');
+                break;
+            case 'xml':
+                $this->setHttpHeader('Content-Type', 'text/xml');
+                break;
+        }
         return $this->httpHeaders;
     }
 
-    public function getHttpHeader($name, $default = null)
+    public function getHttpHeader($name, $default = null, $format = 'json')
     {
-        return isset($this->httpHeaders[$name]) ? $this->httpHeaders[$name] : $default;
+        $httpHeaders = $this->getHttpHeaders($format);
+        return isset($httpHeaders[$name]) ? $httpHeaders[$name] : $default;
     }
 
     public function getResponseBody($format = 'json')
@@ -170,18 +179,10 @@ class OAuth2_Response
             return;
         }
 
-        switch ($format) {
-            case 'json':
-                $this->setHttpHeader('Content-Type', 'application/json');
-                break;
-            case 'xml':
-                $this->setHttpHeader('Content-Type', 'text/xml');
-                break;
-        }
         // status
         header(sprintf('HTTP/%s %s %s', $this->version, $this->statusCode, $this->statusText));
 
-        foreach ($this->getHttpHeaders() as $name => $header) {
+        foreach ($this->getHttpHeaders($format) as $name => $header) {
             header(sprintf('%s: %s', $name, $header));
         }
         echo $this->getResponseBody($format);

--- a/test/OAuth2/ResponseTest.php
+++ b/test/OAuth2/ResponseTest.php
@@ -12,4 +12,24 @@ class OAuth2_ResponseTest extends PHPUnit_Framework_TestCase
         $string = $response->getResponseBody('xml');
         $this->assertContains('<response><bar>foo</bar><oates>halland</oates></response>', $string);
     }
+    public function testRenderAsXmlHeaders()
+    {
+        $response = new OAuth2_Response(array(
+            'foo' => 'bar',
+            'halland' => 'oates',
+        ));
+
+        $headers = $response->getHttpHeaders('xml');
+        $this->assertEquals(array('Content-Type' => 'text/xml'), $headers);
+    }
+    public function testRenderAsJsonHeaders()
+    {
+        $response = new OAuth2_Response(array(
+            'foo' => 'bar',
+            'halland' => 'oates',
+        ));
+
+        $headers = $response->getHttpHeaders();
+        $this->assertEquals(array('Content-Type' => 'application/json'), $headers);
+    }
 }


### PR DESCRIPTION
The headers for JSON and XML output are only set if you call `OAuth2_Response::send()` - the demo OAuth application uses `OAuth2\HttpFoundationBridge\Server`:

https://github.com/bshaffer/oauth2-server-httpfoundation-bridge/blob/master/src/OAuth2/HttpFoundationBridge/Server.php#L31

This doesn't call send() - it calls `getHttpHeaders()`, so I've moved the logic into there, and I've also made `getHttpHeader()` call `$this->getHttpHeaders()`, for consistency.

Please find enclosed two additional tests that prove it works.
