### PR TITLE
Set the authorization header even if it's not Basic Auth

### DIFF
--- a/src/OAuth2/Request.php
+++ b/src/OAuth2/Request.php
@@ -156,11 +156,14 @@ class OAuth2_Request implements OAuth2_RequestInterface
                 }
             }
 
-            // Decode AUTHORIZATION header into PHP_AUTH_USER and PHP_AUTH_PW when authorization header is basic
-            if ((null !== $authorizationHeader) && (0 === stripos($authorizationHeader, 'basic'))) {
-                $exploded = explode(':', base64_decode(substr($authorizationHeader, 6)));
-                if (count($exploded) == 2) {
-                    list($headers['PHP_AUTH_USER'], $headers['PHP_AUTH_PW']) = $exploded;
+            if (null !== $authorizationHeader) {
+                $headers['AUTHORIZATION'] = $authorizationHeader;
+                // Decode AUTHORIZATION header into PHP_AUTH_USER and PHP_AUTH_PW when authorization header is basic
+                if (0 === stripos($authorizationHeader, 'basic')) {
+                    $exploded = explode(':', base64_decode(substr($authorizationHeader, 6)));
+                    if (count($exploded) == 2) {
+                        list($headers['PHP_AUTH_USER'], $headers['PHP_AUTH_PW']) = $exploded;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Here's one more for you. I found that the HTTP_AUTHORIZATION header wasn't set on my apache server, and so requests for resources were failing with the message "The access token was not found".

This commit sets $headers['AUTHORIZATION'] in the request object even if the request isn't using HTTP basic auth.
