### PR TITLE
Make the allow_implicit config check less strict.

### DIFF
--- a/src/OAuth2/Controller/AuthorizeController.php
+++ b/src/OAuth2/Controller/AuthorizeController.php
@@ -122,7 +122,7 @@ class OAuth2_Controller_AuthorizeController implements OAuth2_Controller_Authori
             }
         }
 
-        if ($response_type == self::RESPONSE_TYPE_ACCESS_TOKEN && $this->config['allow_implicit'] === false) {
+        if ($response_type == self::RESPONSE_TYPE_ACCESS_TOKEN && !$this->config['allow_implicit']) {
             $this->response = new OAuth2_Response_Redirect($redirect_uri, 302, 'unsupported_response_type', 'implicit grant type not supported', $state);
             return false;
         }


### PR DESCRIPTION
I'm writing OAuth2 Server integration for Drupal, based on this library.
(Currently at http://drupal.org/sandbox/bojanz/1928198).)

Drupal stores the allow_implicit setting as an integer, which means that the library gets 0 or 1 instead of FALSE or TRUE.
Since the library uses an identical check (===) for the setting, it fails to work correctly.

I see no harm in switching to a less strict check.
