### PR TITLE
Server doesn't pass $scope to getAccessTokenData().

### DIFF
--- a/src/OAuth2/Controller/AccessControllerInterface.php
+++ b/src/OAuth2/Controller/AccessControllerInterface.php
@@ -17,5 +17,5 @@ interface OAuth2_Controller_AccessControllerInterface extends OAuth2_Response_Pr
 {
     public function verifyAccessRequest(OAuth2_RequestInterface $request, $scope = null);
 
-    public function getAccessTokenData(OAuth2_RequestInterface $request);
+    public function getAccessTokenData(OAuth2_RequestInterface $request, $scope = null);
 }

--- a/src/OAuth2/Server.php
+++ b/src/OAuth2/Server.php
@@ -320,9 +320,9 @@ class OAuth2_Server implements OAuth2_Controller_AccessControllerInterface,
         return $value;
     }
 
-    public function getAccessTokenData(OAuth2_RequestInterface $request)
+    public function getAccessTokenData(OAuth2_RequestInterface $request, $scope = null)
     {
-        $value = $this->getAccessController()->getAccessTokenData($request);
+        $value = $this->getAccessController()->getAccessTokenData($request, $scope);
         $this->response = $this->accessController->getResponse();
         return $value;
     }


### PR DESCRIPTION
OAuth2_Controller_AccessController::getAccessTokenData receives a scope parameter, but it is not passed by the server, and it is not present in the interface.

I find it useful, and because it is not passed, I've had to duplicate the scope check outside of the library (in the Drupal integration code). 
Allowing the server to pass $scope along will allow me to remove that duplication.
