### PR TITLE
Missing token param in getAccessTokenData() doesn't return an appropriate error response

### DIFF
--- a/src/OAuth2/Controller/ResourceController.php
+++ b/src/OAuth2/Controller/ResourceController.php
@@ -35,21 +35,15 @@ class OAuth2_Controller_ResourceController implements OAuth2_Controller_Resource
 
     public function getAccessTokenData(OAuth2_RequestInterface $request, $scope = null)
     {
+        // Get the token parameter
         $token_param = $this->tokenType->getAccessTokenParameter($request);
-        $this->response = $this->tokenType->getResponse();
-
-        if(!$token_param){
-            return null;
-        }
-
-        if (!$token_param) { // Access token was not provided
-            $this->response = new OAuth2_Response_AuthenticationError(400, 'invalid_request', 'The request is missing a required parameter, includes an unsupported parameter or parameter value, repeats the same parameter, uses more than one method for including an access token, or is otherwise malformed', $this->tokenType->getTokenType(), $this->config['www_realm'], $scope);
+        if ($token_param === null) {
+            $this->response = $this->tokenType->getResponse();
             return null;
         }
 
         // Get the stored token data (from the implementing subclass)
-        $token = $this->tokenStorage->getAccessToken($token_param);
-        if ($token === null) {
+        if (!$token = $this->tokenStorage->getAccessToken($token_param)) {
             $this->response = new OAuth2_Response_AuthenticationError(401, 'invalid_grant', 'The access token provided is invalid', $this->tokenType->getTokenType(), $this->config['www_realm'], $scope);
             return null;
         }


### PR DESCRIPTION
It seems that the `if (!$token_param) {` check was duplicated, and the first one doesn't set an error response, just returns NULL.

I've removed the first check, so that the second one returns the appropriate response.
