### PR TITLE
Add a getter function for the Response status text.

### DIFF
--- a/src/OAuth2/Response.php
+++ b/src/OAuth2/Response.php
@@ -7,6 +7,7 @@ class OAuth2_Response
 {
     public $version;
     protected $statusCode = 200;
+    protected $statusText;
     protected $parameters = array();
     protected $httpHeaders = array();
 
@@ -106,6 +107,11 @@ class OAuth2_Response
         }
 
         $this->statusText = false === $text ? '' : (null === $text ? self::$statusTexts[$this->statusCode] : $text);
+    }
+
+    public function getStatusText()
+    {
+        return $this->statusText;
     }
 
     public function getParameters()


### PR DESCRIPTION
The setStatusCode() method of the Response class sets a status code and a matching status text.
This variable is not declared by the class, and has no getter.

Since the variable is not declared as protected, I can do

``` php
$status = $response->getStatusCode() . ' ' . $response->statusText;
```

in drupal, but it would be nicer to just be able to do $response->getStatusText(), no?
