### PR TITLE
Pass the default scope to storage.

### DIFF
--- a/src/OAuth2/Controller/AuthorizeController.php
+++ b/src/OAuth2/Controller/AuthorizeController.php
@@ -145,7 +145,7 @@ class OAuth2_Controller_AuthorizeController implements OAuth2_Controller_Authori
         }
 
         // Return retrieved client details together with input
-        return ((array)$request->getAllQueryParameters() + $clientData + array('state' => null));
+        return ((array)$request->getAllQueryParameters() + $clientData + array('scope' => $scope, 'state' => null));
     }
 
     /**

--- a/src/OAuth2/Controller/GrantController.php
+++ b/src/OAuth2/Controller/GrantController.php
@@ -107,13 +107,12 @@ class OAuth2_Controller_GrantController implements OAuth2_Controller_GrantContro
         }
 
         if (!isset($tokenData["scope"])) {
-            $tokenData["scope"] = null;
+            $tokenData["scope"] = $this->scopeUtil->getDefaultScope();
         }
 
         $scope = $this->scopeUtil->getScopeFromRequest($request);
         // Check scope, if provided
-        // @TODO: ScopeStorage
-        if (null != $scope && (!is_array($tokenData) || !isset($tokenData["scope"]) || !$this->scopeUtil->checkScope($scope, $tokenData["scope"]))) {
+        if (!is_null($scope) && !$this->scopeUtil->checkScope($scope, $tokenData["scope"])) {
             $this->response = new OAuth2_Response_Error(400, 'invalid_scope', 'An unsupported scope was requested.');
             return null;
         }


### PR DESCRIPTION
The spec says:

>   If the client omits the scope parameter when requesting
>   authorization, the authorization server MUST either process the
>   request using a pre-defined default value or fail the request
>   indicating an invalid scope.

What I expected is:
- If the request didn't specify a scope, one is requested from the Scope utility class.
- If getDefaultScope() returned FALSE, validation fails. 
- If getDefaultScope() returned a scope, validation succeds.
- The default scope gets passed and set on the generated authorization code / token.

The last assumption doesn't happen. Storage doesn't get the default scope.
Since that seems illogical to me, here's a PR that attempts to fix that.

In GrantController it might make more sense to take the default from the authorization code instead of taking it from the Scope utility class, that's your call.
