### PR TITLE
Add a config setting to make returning scope during implicit flow optional

### DIFF
--- a/src/OAuth2/ResponseType/AccessToken.php
+++ b/src/OAuth2/ResponseType/AccessToken.php
@@ -17,6 +17,7 @@ class OAuth2_ResponseType_AccessToken implements OAuth2_ResponseType_AccessToken
             'token_type'             => 'bearer',
             'access_lifetime'        => 3600,
             'refresh_token_lifetime' => 1209600,
+            'implicit_pass_scope'    => true,
         ), $config);
     }
 
@@ -36,6 +37,11 @@ class OAuth2_ResponseType_AccessToken implements OAuth2_ResponseType_AccessToken
         $includeRefreshToken = false;
         $result["fragment"] = $this->createAccessToken($params['client_id'], $user_id, $params['scope'], $includeRefreshToken);
 
+        // Unset scope if spacified, for cases where passing it would breach
+        // the maximum URL length.
+        if (!$this->config['implicit_pass_scope']) {
+            unset($result['fragment']['scope']);
+        }
         if (isset($params['state'])) {
             $result["fragment"]["state"] = $params['state'];
         }

--- a/src/OAuth2/Server.php
+++ b/src/OAuth2/Server.php
@@ -83,6 +83,7 @@ class OAuth2_Server implements OAuth2_Controller_ResourceControllerInterface,
             'token_bearer_header_name' => 'Bearer',
             'enforce_state'            => false,
             'allow_implicit'           => false,
+            'implicit_pass_scope'      => true,
         ), $config);
 
         foreach ($responseTypes as $key => $responseType) {
@@ -171,7 +172,7 @@ class OAuth2_Server implements OAuth2_Controller_ResourceControllerInterface,
             if (isset($this->storages['refresh_token'])) {
                 $refreshStorage = $this->storages['refresh_token'];
             }
-            $config = array_intersect_key($this->config, array_flip(explode(' ', 'token_type access_lifetime refresh_token_lifetime')));
+            $config = array_intersect_key($this->config, array_flip(explode(' ', 'token_type access_lifetime refresh_token_lifetime implicit_pass_scope')));
             $responseTypes['token'] = new OAuth2_ResponseType_AccessToken($this->storages['access_token'], $refreshStorage, $config);
         }
 


### PR DESCRIPTION
The URL limit is 2083 characters (imposed by Internet Explorer).
During the implicit flow, scope is passed in the URL.
If the server uses long scope names, and the client gets granted several of those, it is easy to breach that limit.

I suggest adding an optional setting to disable scope passing through the URL,
in which case the client needs to fetch the scope through a separate API call
(in my module that is the "verify" call that is required anyway to validate that the received token belongs to the correct client, thus avoiding http://homakov.blogspot.com/2012/08/oauth2-one-accesstoken-to-rule-them-all.html)
