### PR TITLE
Wrap realm & scope values in "" on 401 errors

### DIFF
--- a/src/OAuth2/Response/AuthenticationError.php
+++ b/src/OAuth2/Response/AuthenticationError.php
@@ -8,9 +8,9 @@ class OAuth2_Response_AuthenticationError extends OAuth2_Response_Error
     public function __construct($statusCode, $error, $errorDescription, $tokenType, $realm, $scope = null)
     {
         parent::__construct($statusCode, $error, $errorDescription);
-        $authHeader = sprintf('%s realm=%s', $tokenType, $realm);
+        $authHeader = sprintf('%s realm="%s"', $tokenType, $realm);
         if ($scope) {
-            $authHeader = sprintf('%s, scope=%s', $authHeader, $scope);
+            $authHeader = sprintf('%s, scope="%s"', $authHeader, $scope);
         }
         $this->setHttpHeader('WWW-Authenticate', $authHeader);
     }


### PR DESCRIPTION
The absense of these won't affect most clients but we should consider the few clients (experienced only one so far) that are sensitive to this ... an example ...

On Android, the lack of "" wrapping on realm caused the Java to throw exceptions when trying to read the response code (Android assumes that when we 401 (Unauthorize). The HTTP connection library that Google recommends (HttpUrlConnection) is very strict with errors as well and expects the WWW-Authenticate header to be set and seemingly with the "" ...

Looking at the [The WWW-Authenticate Response Header](http://tools.ietf.org/html/rfc2617#section-3.2.1) spec they seem to imply that the values should be in quotes ... but its not 100% clear.

Some examples I found;

```
header('WWW-Authenticate: OAuth realm="users"');
header('HTTP/1.1 401 Unauthorized');
```

Also wrapped scope with "" anyway

Ps: This solved my issued on an android app connecting to my oauth2-server
