### PR TITLE
Only keep project specific prefs in ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,2 @@
 # Test Files #
 test/config/test.sqlite
-
-# Editor Files #
-*.komodoproject
-
-# OS generated files #
-.DS_Store
-.DS_Store?
-._*
-.Spotlight-V100
-.Trashes
-Icon?
-ehthumbs.db
-Thumbs.db


### PR DESCRIPTION
As per best practice ... .gitignore file will be a lot more elegant if it only lists files that are related to the projects. Global ignore file should keep overall ignores (OS files) & personal prefs like your personal editor generated files
- https://help.github.com/articles/ignoring-files
- http://augustl.com/blog/2009/global_gitignores/

Ps: Sorry for this ... I'm the one who committed these changes to the gitignore file before I'd set up a global_ignore. Didn't know better then.
