### PR TITLE
Better support for unbounded scopes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ $supportedScopes = array(
 );
 $memory = new OAuth2_Storage_Memory(array(
   'default_scope' => $defaultScope,
-  'supported_scopes' => $supportedScoes
+  'supported_scopes' => $supportedScopes
 ));
 $scopeUtil = new OAuth2_Scope($memory);
 
@@ -291,7 +291,7 @@ class OAuth2ScopeTable extends Doctrine_Table implements OAuth2_Storage_ScopeInt
         //...
     }
 
-    public function getSupportedScopes($client_id = null)
+    public function scopeExists($scope, $client_id = null)
     {
         //...
     }

--- a/src/OAuth2/Controller/AuthorizeController.php
+++ b/src/OAuth2/Controller/AuthorizeController.php
@@ -133,7 +133,7 @@ class OAuth2_Controller_AuthorizeController implements OAuth2_Controller_Authori
             return false;
         }
 
-        if (!is_null($scope) && !$this->scopeUtil->checkScope($scope, $this->scopeUtil->getSupportedScopes($client_id))) {
+        if (!is_null($scope) && !$this->scopeUtil->scopeExists($scope, $client_id)) {
             $this->response = new OAuth2_Response_Redirect($redirect_uri, 302, 'invalid_scope', 'An unsupported scope was requested', $state);
             return false;
         }

--- a/src/OAuth2/Scope.php
+++ b/src/OAuth2/Scope.php
@@ -24,7 +24,7 @@ class OAuth2_Scope implements OAuth2_ScopeInterface
      * Check if everything in required scope is contained in available scope.
      *
      * @param $required_scope
-     * Required scope to be check with.
+     * A space-separated string of scopes.
      *
      * @return
      * TRUE if everything in required scope is contained in available scope,
@@ -36,16 +36,25 @@ class OAuth2_Scope implements OAuth2_ScopeInterface
      */
     public function checkScope($required_scope, $available_scope)
     {
-        // The required scope should match or be a subset of the available scope
-        if (!is_array($required_scope)) {
-            $required_scope = explode(' ', trim($required_scope));
-        }
-
-        if (!is_array($available_scope)) {
-            $available_scope = explode(' ', trim($available_scope));
-        }
-
+        $required_scope = explode(' ', trim($required_scope));
+        $available_scope = explode(' ', trim($available_scope));
         return (count(array_diff($required_scope, $available_scope)) == 0);
+    }
+
+    /**
+     * Check if the provided scope exists in storage.
+     *
+     * @param $scope
+     *   A space-separated string of scopes.
+     * @param $client_id
+     *   The requesting client.
+     *
+     * @return
+     *   TRUE if it exists, FALSE otherwise.
+     */
+    public function scopeExists($scope, $client_id = null)
+    {
+        return $this->storage->scopeExists($scope, $client_id);
     }
 
     public function getScopeFromRequest(OAuth2_RequestInterface $request)
@@ -57,10 +66,5 @@ class OAuth2_Scope implements OAuth2_ScopeInterface
     public function getDefaultScope()
     {
         return $this->storage->getDefaultScope();
-    }
-
-    public function getSupportedScopes($client_id = null)
-    {
-        return $this->storage->getSupportedScopes($client_id);
     }
 }

--- a/src/OAuth2/ScopeInterface.php
+++ b/src/OAuth2/ScopeInterface.php
@@ -9,7 +9,7 @@ interface OAuth2_ScopeInterface extends OAuth2_Storage_ScopeInterface
      * Check if everything in required scope is contained in available scope.
      *
      * @param $required_scope
-     * Required scope to be check with.
+     * A space-separated string of scopes.
      *
      * @return
      * TRUE if everything in required scope is contained in available scope,

--- a/src/OAuth2/Storage/Memory.php
+++ b/src/OAuth2/Storage/Memory.php
@@ -148,9 +148,10 @@ class OAuth2_Storage_Memory implements OAuth2_Storage_AuthorizationCodeInterface
         $this->accessTokens[$access_token] = compact('access_token', 'client_id', 'user_id', 'expires', 'scope');
     }
 
-    public function getSupportedScopes($client_id = null)
+    public function scopeExists($scope, $client_id = null)
     {
-        return $this->supportedScopes;
+        $scope = explode(' ', trim($scope));
+        return (count(array_diff($scope, $this->supportedScopes)) == 0);
     }
 
     public function getDefaultScope()

--- a/src/OAuth2/Storage/ScopeInterface.php
+++ b/src/OAuth2/Storage/ScopeInterface.php
@@ -10,30 +10,17 @@
 interface OAuth2_Storage_ScopeInterface
 {
     /**
-     * What scopes are supported by the oauth2 server
-     * Scope names must follow the format specified in the
-     * oauth2 spec
+     * Check if the provided scope exists.
      *
-     * @see http://tools.ietf.org/html/rfc6749#section-3.3
-     *
+     * @param $scope
+     * A space-separated string of scopes.
      * @param $client_id
-     * The requesting client
+     * The requesting client.
      *
      * @return
-     * array or space-delimited string of supported scopes
-     *
-     * ex:
-     *     array(
-     *         'one-scope',
-     *         'two-scope',
-     *         'red-scope',
-     *         'blue-scope',
-     *     );
-     * ex:
-     *     'one-scope two-scope red-scope blue-scope'
-     *
+     * TRUE if it exists, FALSE otherwise.
      */
-    public function getSupportedScopes($client_id = null);
+    public function scopeExists($scope, $client_id = null);
 
     /**
      * The default scope to use in the event the client

--- a/test/OAuth2/Server/Authorize/BasicValidationTest.php
+++ b/test/OAuth2/Server/Authorize/BasicValidationTest.php
@@ -107,7 +107,7 @@ class OAuth2_Server_Authorize_BasicValidationTest extends PHPUnit_Framework_Test
     public function testEnforceScope()
     {
         $server = $this->getTestServer();
-        $scopeStorage = new OAuth2_Storage_Memory(array('default_scope' => false, 'supported_scopes' => 'testscope'));
+        $scopeStorage = new OAuth2_Storage_Memory(array('default_scope' => false, 'supported_scopes' => array('testscope')));
         $server->setScopeUtil(new OAuth2_Scope($scopeStorage));
 
         $request = OAuth2_Request::createFromGlobals();

--- a/test/OAuth2/Util/ScopeTest.php
+++ b/test/OAuth2/Util/ScopeTest.php
@@ -7,43 +7,32 @@ class OAuth2_ScopeTest extends PHPUnit_Framework_TestCase
         $scopeUtil = new OAuth2_Scope();
 
         $this->assertFalse($scopeUtil->checkScope('invalid', 'list of scopes'));
-        $this->assertFalse($scopeUtil->checkScope('invalid', array('list', 'of', 'scopes')));
-
         $this->assertTrue($scopeUtil->checkScope('valid', 'valid and-some other-scopes'));
-        $this->assertTrue($scopeUtil->checkScope('valid', array('valid', 'and-some', 'other-scopes')));
-
         $this->assertTrue($scopeUtil->checkScope('valid another-valid', 'valid another-valid and-some other-scopes'));
-        $this->assertTrue($scopeUtil->checkScope('valid another-valid', array('valid', 'another-valid', 'and-some', 'other-scopes')));
-
         // all scopes must match
         $this->assertFalse($scopeUtil->checkScope('valid invalid', 'valid and-some other-scopes'));
-        $this->assertFalse($scopeUtil->checkScope('valid invalid', array('valid', 'and-some', 'other-scopes')));
         $this->assertFalse($scopeUtil->checkScope('valid valid2 invalid', 'valid valid2 and-some other-scopes'));
-        $this->assertFalse($scopeUtil->checkScope('valid valid2 invalid', array('valid', 'valid2', 'and-some', 'other-scopes')));
     }
 
     public function testScopeStorage()
     {
         $scopeUtil = new OAuth2_Scope();
-
         $this->assertEquals($scopeUtil->getDefaultScope(), null);
-        $this->assertEquals($scopeUtil->getSupportedScopes('client_id'), array());
 
         $scopeUtil = new OAuth2_Scope(array(
             'default_scope' => 'default',
             'supported_scopes' => array('this', 'that', 'another'),
         ));
-
         $this->assertEquals($scopeUtil->getDefaultScope(), 'default');
-        $this->assertEquals($scopeUtil->getSupportedScopes('client_id'), array('this', 'that', 'another'));
+        $this->assertTrue($scopeUtil->scopeExists('this that another', 'client_id'));
 
         $memoryStorage = new OAuth2_Storage_Memory(array(
             'default_scope' => 'base',
-            'supported_scopes' => 'only-this-one',
+            'supported_scopes' => array('only-this-one'),
         ));
         $scopeUtil = new OAuth2_Scope($memoryStorage);
 
         $this->assertEquals($scopeUtil->getDefaultScope(), 'base');
-        $this->assertEquals($scopeUtil->getSupportedScopes('client_id'), 'only-this-one');
+        $this->assertTrue($scopeUtil->scopeExists('only-this-one', 'client_id'));
     }
 }


### PR DESCRIPTION
Implements the general approach agreed on in #76.

Changes:
- Remove the getSupportedScopes() method.
- Add a scopeExists() method to the scope interface, scope storage interface, scope util class, memory storage. The $scope passed is always a space-separated string.
- For consistency with the rest of the system (scopeExists(), any storage method that accepts $scope), I've removed the ability for checkScope() to accept arrays. It now only deals with space-separated strings. Supporting dual forms is also hard to document. We should pick one, and stick with it through the codebase.  
