### PR TITLE
Change Statuscode 400 to 405 if POST-Request is required

### DIFF
--- a/src/OAuth2/Controller/TokenController.php
+++ b/src/OAuth2/Controller/TokenController.php
@@ -64,7 +64,8 @@ class OAuth2_Controller_TokenController implements OAuth2_Controller_TokenContro
     public function grantAccessToken(OAuth2_RequestInterface $request)
     {
         if (strtolower($request->server('REQUEST_METHOD')) != 'post') {
-            $this->response = new OAuth2_Response_Error(400, 'invalid_request', 'The request method must be POST when requesting an access token', 'http://tools.ietf.org/html/rfc6749#section-3.2');
+            $this->response = new OAuth2_Response_Error(405, 'invalid_request', 'The request method must be POST when requesting an access token', 'http://tools.ietf.org/html/rfc6749#section-3.2');
+            $this->response->setHttpHeader( 'Allow', 'POST' );
             return null;
         }
 


### PR DESCRIPTION
As per http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.6 change the statuscode from 400 to 405 and include `Allow`-header indicating that POST must be used to grant an access token.
