### PR TITLE
UserCredentials - Set Token Scope to Requested

### DIFF
--- a/src/OAuth2/Controller/TokenController.php
+++ b/src/OAuth2/Controller/TokenController.php
@@ -120,6 +120,9 @@ class OAuth2_Controller_TokenController implements OAuth2_Controller_TokenContro
         }
 
         $tokenData['user_id'] = isset($tokenData['user_id']) ? $tokenData['user_id'] : null;
+        
+        // Set scope to requested scope, even if the user has access to other scopes too
+        $tokenData['scope'] = $scope;
 
         return $grantType->createAccessToken($this->accessToken, $clientData, $tokenData);
     }


### PR DESCRIPTION
For the user credentials grant, if a user is granted for example scope1, scope2, scope3, and then requests an access token only for scope1, they receive an access token for all three scopes. This is in line with the spec, 3.3: 

```
The authorization server MAY fully or partially ignore the scope
requested by the client based on the authorization server policy or
the resource owner's instructions."
```

So the change is to make it more restrictive, so that the access token only is valid for the scopes asked for (which I believe is also in line with the spec?) even though the resource owner may request access tokens that covers more scopes at another time.

My apologies if I have missed something.
