### PR TITLE
user_id not required for authorization_code grant

### DIFF
--- a/src/OAuth2/GrantType/AuthorizationCode.php
+++ b/src/OAuth2/GrantType/AuthorizationCode.php
@@ -80,7 +80,7 @@ class AuthorizationCode implements GrantTypeInterface
 
     public function getUserId()
     {
-        return $this->authCode['user_id'];
+        return isset($this->authCode['user_id']) ? $this->authCode['user_id'] : null;
     }
 
     public function createAccessToken(AccessTokenInterface $accessToken, $client_id, $user_id, $scope)


### PR DESCRIPTION
Explained in #167
