### PR TITLE
make user_id not required for refresh_token grant

### DIFF
--- a/src/OAuth2/GrantType/RefreshToken.php
+++ b/src/OAuth2/GrantType/RefreshToken.php
@@ -60,7 +60,7 @@ class RefreshToken implements GrantTypeInterface
 
     public function getUserId()
     {
-        return $this->refreshToken['user_id'];
+        return isset($this->refreshToken['user_id']) ? $this->refreshToken['user_id'] : null;
     }
 
     public function getScope()


### PR DESCRIPTION
Same as issue #167 and PR #168 but for refresh_token grant.

`OAuth2_Storage_RefreshTokenInterface::getRefreshToken()` does not require `user_id` to be returned, but `RefreshToken::getUserId()` expects it to be set in the refresh_token data fetched from storage.
