### PR TITLE
Make using a PDO_SQLITE_DSN possible without warnings

### DIFF
--- a/src/OAuth2/Storage/Pdo.php
+++ b/src/OAuth2/Storage/Pdo.php
@@ -18,7 +18,7 @@ class OAuth2_Storage_Pdo implements OAuth2_Storage_AuthorizationCodeInterface,
 {
     protected $db;
     protected $config;
-     
+
     public function __construct($connection, $config = array())
     {
         if (!$connection instanceof PDO) {


### PR DESCRIPTION
Hey Brent,  I wanted to run the token server on an sqlite3 database, the provided (mysql) create queries seemed to work flawlessly, but the code need a few changes to not error out since you don't need username/passwor for sqlite3..

Tx for sharing.
