### PR TITLE
Implement ScopeInterface for PDO, Redis

### DIFF
--- a/src/OAuth2/Storage/Redis.php
+++ b/src/OAuth2/Storage/Redis.php
@@ -16,7 +16,8 @@ class Redis implements AuthorizationCodeInterface,
     ClientCredentialsInterface,
     UserCredentialsInterface,
     RefreshTokenInterface,
-    JwtBearerInterface
+    JwtBearerInterface,
+    ScopeInterface
 {
     private $redis;
     private $config;
@@ -193,6 +194,28 @@ class Redis implements AuthorizationCodeInterface,
             compact('access_token', 'client_id', 'user_id', 'expires', 'scope'),
             $expires
         );
+    }
+
+    /* ScopeInterface */
+    public function scopeExists($scope, $client_id = null)
+    {
+        $details = $this->getClientDetails($client_id);
+        if (isset($details['supported_scopes'])) {
+            $clientSupportedScopes = explode(' ', $details['supported_scopes']);
+            $scope = explode(' ', $scope);
+
+            return (count(array_diff($scope, $clientSupportedScopes)) == 0);
+        }
+        return false;
+    }
+
+    public function getDefaultScope($client_id = null)
+    {
+        $details = $this->getClientDetails($client_id);
+        if (isset($details['default_scope'])) {
+            return $details['default_scope'];
+        }
+        return null;
     }
 
     /*JWTBearerInterface */

--- a/test/OAuth2/StorageTest.php
+++ b/test/OAuth2/StorageTest.php
@@ -32,6 +32,35 @@ class StorageTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @dataProvider provideStorage */
+    public function testClientScopeExists(ClientInterface $storage = null)
+    {
+        if (is_null($storage)) {
+            $this->markTestSkipped('Unable to load class Mongo_Client');
+            return;
+        }
+
+        //Test getting scopes with a client_id
+        $scopeUtil = new Scope($storage);
+        $this->assertTrue($scopeUtil->scopeExists('clientscope1 clientscope2', 'Test Client ID'));
+        $this->assertTrue($scopeUtil->scopeExists('clientscope3', 'Test Client ID 2'));
+        $this->assertFalse($scopeUtil->scopeExists('clientscope1 clientscope2 clientscope3', 'Test Client ID'));
+    }
+
+    /** @dataProvider provideStorage */
+    public function testGetDefaultClientScope(ClientInterface $storage = null)
+    {
+        if (is_null($storage)) {
+            $this->markTestSkipped('Unable to load class Mongo_Client');
+            return;
+        }
+
+        //Test getting scopes with a client_id
+        $scopeUtil = new Scope($storage);
+        $this->assertEquals($scopeUtil->getDefaultScope('Test Default Scope Client ID'), 'clientscope1 clientscope2');
+        $this->assertEquals($scopeUtil->getDefaultScope('Test Default Scope Client ID 2'), 'clientscope3');
+    }
+
+    /** @dataProvider provideStorage */
     public function testGetClientDetails(ClientInterface $storage = null)
     {
         if (is_null($storage)) {

--- a/test/lib/OAuth2/Storage/Bootstrap.php
+++ b/test/lib/OAuth2/Storage/Bootstrap.php
@@ -71,13 +71,17 @@ class Bootstrap
 
     private function createSqliteDb(\PDO $pdo)
     {
-        $pdo->exec('CREATE TABLE oauth_clients (client_id TEXT, client_secret TEXT, redirect_uri TEXT, grant_types TEXT)');
+        $pdo->exec('CREATE TABLE oauth_clients (client_id TEXT, client_secret TEXT, redirect_uri TEXT, grant_types TEXT, supported_scopes TEXT, default_scope TEXT)');
         $pdo->exec('CREATE TABLE oauth_access_tokens (access_token TEXT, client_id TEXT, user_id TEXT, expires TIMESTAMP, scope TEXT)');
         $pdo->exec('CREATE TABLE oauth_authorization_codes (authorization_code TEXT, client_id TEXT, user_id TEXT, redirect_uri TEXT, expires TIMESTAMP, scope TEXT)');
         $pdo->exec('CREATE TABLE oauth_users (username TEXT, password TEXT, first_name TEXT, last_name TEXT)');
         $pdo->exec('CREATE TABLE oauth_refresh_tokens (refresh_token TEXT, client_id TEXT, user_id TEXT, expires TIMESTAMP, scope TEXT)');
 
         // test data
+        $pdo->exec('INSERT INTO oauth_clients (client_id, client_secret, supported_scopes, default_scope) VALUES ("Test Client ID", "TestSecret", "clientscope1 clientscope2", "clientscope1 clientscope2")');
+        $pdo->exec('INSERT INTO oauth_clients (client_id, client_secret, supported_scopes, default_scope) VALUES ("Test Client ID 2", "TestSecret", "clientscope3", "clientscope3")');
+        $pdo->exec('INSERT INTO oauth_clients (client_id, client_secret, supported_scopes, default_scope) VALUES ("Test Default Scope Client ID", "TestSecret", "clientscope1 clientscope2", "clientscope1 clientscope2")');
+        $pdo->exec('INSERT INTO oauth_clients (client_id, client_secret, supported_scopes, default_scope) VALUES ("Test Default Scope Client ID 2", "TestSecret", "clientscope3", "clientscope3")');
         $pdo->exec('INSERT INTO oauth_clients (client_id, client_secret, grant_types) VALUES ("oauth_test_client", "testpass", "implicit password")');
         $pdo->exec('INSERT INTO oauth_access_tokens (access_token, client_id) VALUES ("testtoken", "Some Client")');
         $pdo->exec('INSERT INTO oauth_authorization_codes (authorization_code, client_id) VALUES ("testcode", "Some Client")');
@@ -95,13 +99,17 @@ class Bootstrap
     {
         $pdo->exec('CREATE DATABASE oauth2_server_php');
         $pdo->exec('USE oauth2_server_php');
-        $pdo->exec('CREATE TABLE oauth_clients (client_id TEXT, client_secret TEXT, redirect_uri TEXT, grant_types TEXT)');
+        $pdo->exec('CREATE TABLE oauth_clients (client_id TEXT, client_secret TEXT, redirect_uri TEXT, grant_types TEXT, supported_scopes TEXT, default_scope TEXT)');
         $pdo->exec('CREATE TABLE oauth_access_tokens (access_token TEXT, client_id TEXT, user_id TEXT, expires DATETIME, scope TEXT)');
         $pdo->exec('CREATE TABLE oauth_authorization_codes (authorization_code TEXT, client_id TEXT, user_id TEXT, redirect_uri TEXT, expires DATETIME, scope TEXT)');
         $pdo->exec('CREATE TABLE oauth_users (username TEXT, password TEXT, first_name TEXT, last_name TEXT)');
         $pdo->exec('CREATE TABLE oauth_refresh_tokens (refresh_token TEXT, client_id TEXT, user_id TEXT, expires DATETIME, scope TEXT)');
 
         // test data
+        $pdo->exec('INSERT INTO oauth_clients (client_id, client_secret, supported_scopes, default_scope) VALUES ("Test Client ID", "TestSecret", "clientscope1 clientscope2", "clientscope1 clientscope2")');
+        $pdo->exec('INSERT INTO oauth_clients (client_id, client_secret, supported_scopes, default_scope) VALUES ("Test Client ID 2", "TestSecret", "clientscope3", "clientscope3")');
+        $pdo->exec('INSERT INTO oauth_clients (client_id, client_secret, supported_scopes, default_scope) VALUES ("Test Default Scope Client ID", "TestSecret", "clientscope1 clientscope2", "clientscope1 clientscope2")');
+        $pdo->exec('INSERT INTO oauth_clients (client_id, client_secret, supported_scopes, default_scope) VALUES ("Test Default Scope Client ID 2", "TestSecret", "clientscope3", "clientscope3")');
         $pdo->exec('INSERT INTO oauth_clients (client_id, client_secret, grant_types) VALUES ("oauth_test_client", "testpass", "implicit password")');
         $pdo->exec('INSERT INTO oauth_access_tokens (access_token, client_id) VALUES ("testtoken", "Some Client")');
         $pdo->exec('INSERT INTO oauth_authorization_codes (authorization_code, client_id) VALUES ("testcode", "Some Client")');

--- a/test/lib/OAuth2/Storage/MockRedisClient.php
+++ b/test/lib/OAuth2/Storage/MockRedisClient.php
@@ -13,6 +13,30 @@ class MockRedisClient
                 'redirect_uri' => '',
                 'grant_types' => 'implicit password',
             ),
+            'oauth_clients:Test Client ID' => array(
+                'client_id' => 'Test Client ID',
+                'client_secret' => "TestSecret",
+                'supported_scopes' => 'clientscope1 clientscope2',
+                'default_scope' => 'clientscope1 clientscope2',
+            ),
+            'oauth_clients:Test Client ID 2' => array(
+                'client_id' => 'Test Client ID 2',
+                'client_secret' => "TestSecret",
+                'supported_scopes' => 'clientscope3',
+                'default_scope' => 'clientscope3',
+            ),
+            'oauth_clients:Test Default Scope Client ID' => array(
+                'client_id' => 'Test Default Scope Client ID',
+                'client_secret' => "TestSecret",
+                'supported_scopes' => 'clientscope1 clientscope2',
+                'default_scope' => 'clientscope1 clientscope2',
+            ),
+            'oauth_clients:Test Default Scope Client ID 2' => array(
+                'client_id' => 'Test Default Scope Client ID 2',
+                'client_secret' => "TestSecret",
+                'supported_scopes' => 'clientscope3',
+                'default_scope' => 'clientscope3',
+            ),
             'oauth_access_tokens:testtoken' => array(
                 'access_token' => 'testtoken',
                 'client_id' => "Some Client",


### PR DESCRIPTION
- Added tests and supporting data for Memory, PDO, Redis
- Implements https://github.com/bshaffer/oauth2-server-php/issues/208, https://github.com/bshaffer/oauth2-server-php/issues/215
- Uses Memory storage as template for test data
