### PR TITLE
Allow putting token in the body of a PUT request

### DIFF
--- a/src/OAuth2/TokenType/Bearer.php
+++ b/src/OAuth2/TokenType/Bearer.php
@@ -72,9 +72,9 @@ class Bearer implements TokenTypeInterface
         }
 
         if ($request->request($this->config['token_param_name'])) {
-            // POST: Get the token from POST data
-            if (strtolower($request->server('REQUEST_METHOD')) != 'post') {
-                $response->setError(400, 'invalid_request', 'When putting the token in the body, the method must be POST');
+            // POST: Get the token from POST or PUT data
+            if (!in_array(strtolower($request->server('REQUEST_METHOD')), array('post', 'put'))) {
+                $response->setError(400, 'invalid_request', 'When putting the token in the body, the method must be POST or PUT');
                 return null;
             }
 


### PR DESCRIPTION
Brent, I'm not super sharp on the OAuth2 specifications, but it would seem right to me that one could submit a token in the body of a PUT request, very similar to how a POST request works.

Right now the library throws an `invalid_request` error when trying to do this, which makes it difficult to use in a RESTful API.

Here is a patch to fix it.
