### PR TITLE
Updated getClientCredentials() to be able get client credentials from Authorization header

### DIFF
--- a/src/OAuth2/ClientAssertionType/HttpBasic.php
+++ b/src/OAuth2/ClientAssertionType/HttpBasic.php
@@ -78,8 +78,17 @@ class HttpBasic implements ClientAssertionTypeInterface
      */
     public function getClientCredentials(RequestInterface $request, ResponseInterface $response = null)
     {
-        if (!is_null($request->headers('PHP_AUTH_USER')) && !is_null($request->headers('PHP_AUTH_PW'))) {
-            return array('client_id' => $request->headers('PHP_AUTH_USER'), 'client_secret' => $request->headers('PHP_AUTH_PW'));
+        if (!is_null($request->server('PHP_AUTH_USER')) && !is_null($request->server('PHP_AUTH_PW'))) {
+            return array('client_id' => $request->server('PHP_AUTH_USER'), 'client_secret' => $request->server('PHP_AUTH_PW'));
+        }
+
+        $authorizationHeader = $request->headers('AUTHORIZATION');
+
+        if ($authorizationHeader && 0 === stripos($authorizationHeader, 'basic')) {
+            $exploded = explode(':', base64_decode(substr($authorizationHeader, 6)));
+            if (count($exploded) == 2) {
+                return array('client_id' => $exploded[0], 'client_secret' => $exploded[1]);
+            }
         }
 
         if ($this->config['allow_credentials_in_request_body']) {


### PR DESCRIPTION
And yes @bshaffer I know you don't like it https://github.com/bshaffer/oauth2-server-php/issues/240 but still can we vote for it? :D

It works, but don't merge this. `Response::getHeadersFromServer()` needs to be updated too. Can you say why we need `getHeadersFromServer()`? maybe this is CGI issue or IIS? on apache working fine..

And sorry if I am very wrong.
