### PR TITLE
Make Bearer token type consistent

### DIFF
--- a/src/OAuth2/Request.php
+++ b/src/OAuth2/Request.php
@@ -97,7 +97,20 @@ class Request implements RequestInterface
      */
     public function getContent($asResource = false)
     {
-        $this->content = \Request::getContent();
+        if (false === $this->content || (true === $asResource && null !== $this->content)) {
+            throw new \LogicException('getContent() can only be called once when using the resource return type.');
+        }
+
+        if (true === $asResource) {
+            $this->content = false;
+
+            return fopen('php://input', 'rb');
+        }
+
+        if (null === $this->content) {
+            $this->content = file_get_contents('php://input');
+        }
+
         return $this->content;
     }
 


### PR DESCRIPTION
Bearer token type was "bearer", however header expected "Bearer". This prevented callers from using the returned token type with the Authorization heder in subsequent calls
