### PR TITLE
Modified validateAuthorizeRequest to return client data array

### DIFF
--- a/src/OAuth2/Controller/AuthorizeController.php
+++ b/src/OAuth2/Controller/AuthorizeController.php
@@ -220,7 +220,7 @@ class AuthorizeController implements AuthorizeControllerInterface
         $this->response_type = $response_type;
 
         // return client data array
-        return $clientdata;
+        return $clientData;
     }
 
     /**


### PR DESCRIPTION
[The documentation](http://bshaffer.github.io/oauth2-server-php-docs/overview/methods/) states that `validateAuthorizeReqest()` returns an array of client data. However, a modification was made that caused `validateAuthorizeRequest()` to return _true_ instead. I've reverted this change and updated in-file comments respectively.
