### PR TITLE
Fixing CryptoToken refresh token lifetime

### DIFF
--- a/src/OAuth2/ResponseType/CryptoToken.php
+++ b/src/OAuth2/ResponseType/CryptoToken.php
@@ -77,7 +77,7 @@ class CryptoToken extends AccessToken
          */
         if ($includeRefreshToken && $this->refreshStorage) {
             $cryptoToken["refresh_token"] = $this->generateRefreshToken();
-            $this->refreshStorage->setRefreshToken($cryptoToken['refresh_token'], $client_id, $user_id, $expires, $scope);
+            $this->refreshStorage->setRefreshToken($cryptoToken['refresh_token'], $client_id, $user_id, time() + $this->config['refresh_token_lifetime'], $scope);
         }
 
         /*


### PR DESCRIPTION
Fix to #252 CryptoToken response uses 'access_lifetime' instead of 'refresh_token_lifetime'
