### PR TITLE
Response Object is empty if there is no given AccessToken on Resource

### DIFF
--- a/src/OAuth2/Controller/ResourceController.php
+++ b/src/OAuth2/Controller/ResourceController.php
@@ -73,7 +73,14 @@ class ResourceController implements ResourceControllerInterface
     public function getAccessTokenData(RequestInterface $request, ResponseInterface $response)
     {
         // Get the token parameter
-        if ($token_param = $this->tokenType->getAccessTokenParameter($request, $response)) {
+        $token_param = $this->tokenType->getAccessTokenParameter($request, $response);
+        // Make sure the token is provided
+
+        if (is_null($token_param)) {
+            $response->setError(401, 'invalid_token', 'Protected resource and no access token provided.');
+        }
+
+        if ($token_param) {
             // Get the stored token data (from the implementing subclass)
             // Check we have a well formed token
             // Check token expiration (expires is a mandatory paramter)


### PR DESCRIPTION
The Response Object has empty messages if the client access a restricted resource without providing an Access Token.

Test:

```
http://localhost/resource.php
```

Client can connect using an Access Token as: 

```
http://localhost/resource.php?access_token=xxxxxx
```

If it ask for it without providing the param "access_token" the Response Object replies: 

```
[]
```

OAuth2 standard dictates that you should reply with some kind of information (http://tools.ietf.org/html/rfc6749#section-7.2).

With this patch the server replies:

``` json
{
error: "invalid_token",
error_description: "Protected resource and no access token provided."
}
```
