### PR TITLE
Added the password/client_secret encryption using bcrypt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Test Files #
 test/config/test.sqlite
 vendor
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     ],
     "homepage": "http://github.com/bshaffer/oauth2-server-php",
     "require":{
-        "php":">=5.2.0"
+        "php":">=5.3.3",
+        "zendframework/zend-crypt":">=2.2.0"
     },
     "autoload": {
         "psr-0": { "OAuth2": "src/" }

--- a/src/OAuth2/Storage/AbstractStorage.php
+++ b/src/OAuth2/Storage/AbstractStorage.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace OAuth2\Storage;
+
+use Zend\Crypt\Password\Bcrypt;
+
+/**
+ * Abstract Storage
+ *
+ * NOTE: Passwords are stored using bcrypt
+ * @see http://framework.zend.com/manual/2.2/en/modules/zend.crypt.password.html#bcrypt
+ */
+abstract class AbstractStorage
+{
+    const BCRYPT_COST = '10';
+
+    protected $bcrypt;
+
+    public function __construct($config = array())
+    {
+        $this->bcrypt = new Bcrypt();
+        if (isset($config['bcrypt_cost'])) {
+            $this->bcrypt->setCost($config['bcrypt_cost']);
+        } else {
+            $this->bcrypt->setCost(self::BCRYPT_COST);
+        }
+    }
+
+    /**
+     * Check the validity of credential (secret or password)
+     *
+     * @param string $credential
+     * @param string $valueToCheck
+     * @return boolean
+     */
+    public function checkCredential($credential, $valueToCheck)
+    {
+        // backward compatibility support: plaintext, sha1 and bcrypt
+        if ($credential === $valueToCheck) {
+            return true;
+        }
+        if ($credential === sha1($valueToCheck)) {
+            return true;
+        }
+        try {
+            $result = $this->bcrypt->verify($valueToCheck, $credential);
+        } catch (\Zend\Crypt\Password\Exception\RuntimeException $e) {
+            return false;
+        }
+        return $result;
+
+    }
+ 
+}

--- a/src/OAuth2/Storage/Memory.php
+++ b/src/OAuth2/Storage/Memory.php
@@ -10,7 +10,7 @@ namespace OAuth2\Storage;
  *
  * @author Brent Shaffer <bshafs at gmail dot com>
  */
-class Memory implements AuthorizationCodeInterface,
+class Memory extends AbstractStorage implements AuthorizationCodeInterface,
     UserCredentialsInterface,
     AccessTokenInterface,
     ClientCredentialsInterface,
@@ -61,6 +61,8 @@ class Memory implements AuthorizationCodeInterface,
         $this->clientDefaultScopes = $params['client_default_scopes'];
         $this->defaultScope = $params['default_scope'];
         $this->keys = $params['keys'];
+
+        parent::__construct();
     }
 
     /* AuthorizationCodeInterface */

--- a/test/OAuth2/Storage/ClientTest.php
+++ b/test/OAuth2/Storage/ClientTest.php
@@ -76,7 +76,7 @@ class ClientTest extends BaseTest
 
         // valid client_id
         $details = $storage->getClientDetails($clientId);
-        $this->assertEquals($details['client_secret'], 'somesecret');
+        $this->assertTrue($storage->checkCredential($details['client_secret'], 'somesecret'));
         $this->assertEquals($details['redirect_uri'], 'http://test.com');
         $this->assertEquals($details['grant_types'], 'client_credentials');
         $this->assertEquals($details['user_id'], 'brent@brentertainment.com');


### PR DESCRIPTION
I added the password and client_secret encryption using bcrypt. I created an AbstractStorage class to manage the bcrypt component. I implemented a checkCredential() method to check password for backward compatibility (plain text, SHA1 and bcrypt). I added the bcrypt protection in Pdo, Memory (only in construct), Mongo, Redis storage adapters.
I used the Zend\Crypt\Password\Bcrypt component of ZF2. The ZF2 requires PHP 5.3.3+, I changed the composer.json (this is a BC, the previous requirement was PHP 5.2.0+).
