### PR TITLE
changed response header from 200 to 401 when empty token received

### DIFF
--- a/src/OAuth2/TokenType/Bearer.php
+++ b/src/OAuth2/TokenType/Bearer.php
@@ -57,7 +57,7 @@ class Bearer implements TokenTypeInterface
          *
          * @see http://tools.ietf.org/html/rfc6750#section-3.1
          */
-        $methodsUsed = !empty($headers) + !is_null($request->query($this->config['token_param_name'])) + !is_null($request->request($this->config['token_param_name']));
+        $methodsUsed = !empty($headers) + (bool)($request->query($this->config['token_param_name'])) + (bool)($request->request($this->config['token_param_name']));
         if ($methodsUsed > 1) {
             $response->setError(400, 'invalid_request', 'Only one method may be used to authenticate at a time (Auth header, GET or POST)');
 


### PR DESCRIPTION
The resource controller returns 200 when a request is made with an empty token e.g:

401 resource.php
200 resource.php?access_token=
401 resource.php?access_token=asd
200 resource.php?access_token=46422d7e0b0db9093526c08c47ef33da388bbb9a
