### PR TITLE
more information on skipped storage when applicable

### DIFF
--- a/src/OAuth2/Storage/Redis.php
+++ b/src/OAuth2/Storage/Redis.php
@@ -76,7 +76,7 @@ class Redis implements AuthorizationCodeInterface,
 
         // check that the key was set properly
         // if this fails, an exception will usually thrown, so this step isn't strictly necessary
-        return $ret->getPayload() == 'OK';
+        return is_bool($ret) ? $ret : $ret->getPayload() == 'OK';
     }
 
     protected function expireValue($key)

--- a/test/OAuth2/Storage/AccessTokenTest.php
+++ b/test/OAuth2/Storage/AccessTokenTest.php
@@ -7,11 +7,12 @@ class AccessTokenTest extends BaseTest
     /** @dataProvider provideStorage */
     public function testSetAccessToken(AccessTokenInterface $storage = null)
     {
-        if (is_null($storage)) {
-            $this->markTestSkipped('Skipped Storage');
+        if ($storage instanceof NullStorage) {
+            $this->markTestSkipped('Skipped Storage: ' . $storage);
 
             return;
         }
+
         // assert token we are about to add does not exist
         $token = $storage->getAccessToken('newtoken');
         $this->assertFalse($token);

--- a/test/OAuth2/Storage/AuthorizationCodeTest.php
+++ b/test/OAuth2/Storage/AuthorizationCodeTest.php
@@ -7,11 +7,12 @@ class AuthorizationCodeTest extends BaseTest
     /** @dataProvider provideStorage */
     public function testGetAuthorizationCode(AuthorizationCodeInterface $storage = null)
     {
-        if (is_null($storage)) {
-            $this->markTestSkipped('Skipped Storage');
+        if ($storage instanceof NullStorage) {
+            $this->markTestSkipped('Skipped Storage: ' . $storage);
 
             return;
         }
+
         // nonexistant client_id
         $details = $storage->getAuthorizationCode('faketoken');
         $this->assertFalse($details);
@@ -24,11 +25,12 @@ class AuthorizationCodeTest extends BaseTest
     /** @dataProvider provideStorage */
     public function testSetAuthorizationCode(AuthorizationCodeInterface $storage = null)
     {
-        if (is_null($storage)) {
-            $this->markTestSkipped('Skipped Storage');
+        if ($storage instanceof NullStorage) {
+            $this->markTestSkipped('Skipped Storage: ' . $storage);
 
             return;
         }
+
         // assert code we are about to add does not exist
         $code = $storage->getAuthorizationCode('newcode');
         $this->assertFalse($code);

--- a/test/OAuth2/Storage/ClientCredentialsTest.php
+++ b/test/OAuth2/Storage/ClientCredentialsTest.php
@@ -7,11 +7,12 @@ class ClientCredentialsTest extends BaseTest
     /** @dataProvider provideStorage */
     public function testCheckClientCredentials(ClientCredentialsInterface $storage = null)
     {
-        if (is_null($storage)) {
-            $this->markTestSkipped('Skipped Storage');
+        if ($storage instanceof NullStorage) {
+            $this->markTestSkipped('Skipped Storage: ' . $storage);
 
             return;
         }
+
         // nonexistant client_id
         $pass = $storage->checkClientCredentials('fakeclient', 'testpass');
         $this->assertFalse($pass);

--- a/test/OAuth2/Storage/ClientTest.php
+++ b/test/OAuth2/Storage/ClientTest.php
@@ -7,11 +7,12 @@ class ClientTest extends BaseTest
     /** @dataProvider provideStorage */
     public function testGetClientDetails(ClientInterface $storage = null)
     {
-        if (is_null($storage)) {
-            $this->markTestSkipped('Skipped Storage');
+        if ($storage instanceof NullStorage) {
+            $this->markTestSkipped('Skipped Storage: ' . $storage);
 
             return;
         }
+
         // nonexistant client_id
         $details = $storage->getClientDetails('fakeclient');
         $this->assertFalse($details);
@@ -27,8 +28,8 @@ class ClientTest extends BaseTest
     /** @dataProvider provideStorage */
     public function testCheckRestrictedGrantType(ClientInterface $storage = null)
     {
-        if (is_null($storage)) {
-            $this->markTestSkipped('Skipped Storage');
+        if ($storage instanceof NullStorage) {
+            $this->markTestSkipped('Skipped Storage: ' . $storage);
 
             return;
         }
@@ -45,11 +46,12 @@ class ClientTest extends BaseTest
     /** @dataProvider provideStorage */
     public function testGetAccessToken(ClientInterface $storage = null)
     {
-        if (is_null($storage)) {
-            $this->markTestSkipped('Skipped Storage');
+        if ($storage instanceof NullStorage) {
+            $this->markTestSkipped('Skipped Storage: ' . $storage);
 
             return;
         }
+
         // nonexistant client_id
         $details = $storage->getAccessToken('faketoken');
         $this->assertFalse($details);
@@ -62,8 +64,8 @@ class ClientTest extends BaseTest
     /** @dataProvider provideStorage */
     public function testSaveClient(ClientInterface $storage = null)
     {
-        if (is_null($storage)) {
-            $this->markTestSkipped('Skipped Storage');
+        if ($storage instanceof NullStorage) {
+            $this->markTestSkipped('Skipped Storage: ' . $storage);
 
             return;
         }

--- a/test/OAuth2/Storage/CryptoTokenTest.php
+++ b/test/OAuth2/Storage/CryptoTokenTest.php
@@ -9,6 +9,13 @@ class CryptoTokenTest extends BaseTest
     /** @dataProvider provideStorage */
     public function testSetAccessToken($storage)
     {
+        if (!$storage instanceof PublicKey) {
+            // incompatible storage
+            return;
+        }
+
+        $crypto = new CryptoToken($storage);
+
         $publicKeyStorage = Bootstrap::getInstance()->getMemoryStorage();
         $encryptionUtil = new Jwt();
 
@@ -18,11 +25,11 @@ class CryptoTokenTest extends BaseTest
             'scope'   => 'foo',
         );
 
-        $token = $encryptionUtil->encode($cryptoToken, $publicKeyStorage->getPrivateKey(), $publicKeyStorage->getEncryptionAlgorithm());
+        $token = $encryptionUtil->encode($cryptoToken, $storage->getPrivateKey(), $storage->getEncryptionAlgorithm());
 
         $this->assertNotNull($token);
 
-        $tokenData = $storage->getAccessToken($token);
+        $tokenData = $crypto->getAccessToken($token);
 
         $this->assertTrue(is_array($tokenData));
 
@@ -30,16 +37,5 @@ class CryptoTokenTest extends BaseTest
         $this->assertEquals($tokenData['access_token'], $cryptoToken['access_token']);
         $this->assertEquals($tokenData['expires'], $cryptoToken['expires']);
         $this->assertEquals($tokenData['scope'], $cryptoToken['scope']);
-    }
-
-    // @TODO - use the BaseTest provideStorage, and add support for storages which omit certain interfaces
-    public function provideStorage()
-    {
-        $memory = Bootstrap::getInstance()->getMemoryStorage();
-        $storage = new CryptoToken($memory);
-
-        return array(
-            array($storage)
-        );
     }
 }

--- a/test/OAuth2/Storage/PublicKeyTest.php
+++ b/test/OAuth2/Storage/PublicKeyTest.php
@@ -7,8 +7,10 @@ class PublicKeyTest extends BaseTest
     /** @dataProvider provideStorage */
     public function testSetAccessToken($storage)
     {
-        if (is_null($storage)) {
-            return $this->markTestSkipped('Skipped Storage');
+        if ($storage instanceof NullStorage) {
+            $this->markTestSkipped('Skipped Storage: ' . $storage);
+
+            return;
         }
 
         if (!$storage instanceof PublicKeyInterface) {

--- a/test/OAuth2/Storage/RefreshTokenTest.php
+++ b/test/OAuth2/Storage/RefreshTokenTest.php
@@ -7,11 +7,12 @@ class RefreshTokenTest extends BaseTest
     /** @dataProvider provideStorage */
     public function testSetRefreshToken(RefreshTokenInterface $storage = null)
     {
-        if (is_null($storage)) {
-            $this->markTestSkipped('Skipped Storage');
+        if ($storage instanceof NullStorage) {
+            $this->markTestSkipped('Skipped Storage: ' . $storage);
 
             return;
         }
+
         // assert token we are about to add does not exist
         $token = $storage->getRefreshToken('refreshtoken');
         $this->assertFalse($token);

--- a/test/OAuth2/Storage/ScopeTest.php
+++ b/test/OAuth2/Storage/ScopeTest.php
@@ -9,8 +9,10 @@ class ScopeTest extends BaseTest
     /** @dataProvider provideStorage */
     public function testScopeExists($storage = null)
     {
-        if (is_null($storage)) {
-            return $this->markTestSkipped('Skipped Storage');
+        if ($storage instanceof NullStorage) {
+            $this->markTestSkipped('Skipped Storage: ' . $storage);
+
+            return;
         }
 
         if (!$storage instanceof ScopeInterface) {
@@ -29,8 +31,10 @@ class ScopeTest extends BaseTest
     /** @dataProvider provideStorage */
     public function testGetDefaultScope($storage = null)
     {
-        if (is_null($storage)) {
-            return $this->markTestSkipped('Skipped Storage');
+        if ($storage instanceof NullStorage) {
+            $this->markTestSkipped('Skipped Storage: ' . $storage);
+
+            return;
         }
 
         if (!$storage instanceof ScopeInterface) {

--- a/test/OAuth2/Storage/UserCredentialsTest.php
+++ b/test/OAuth2/Storage/UserCredentialsTest.php
@@ -7,11 +7,12 @@ class UserCredentialsTest extends BaseTest
     /** @dataProvider provideStorage */
     public function testCheckUserCredentials(UserCredentialsInterface $storage = null)
     {
-        if (is_null($storage)) {
-            $this->markTestSkipped('Skipped Storage');
+        if ($storage instanceof NullStorage) {
+            $this->markTestSkipped('Skipped Storage: ' . $storage);
 
             return;
         }
+
         // create a new user for testing
         $success = $storage->setUser('testusername', 'testpass', 'Test', 'User');
         $this->assertTrue($success);

--- a/test/lib/OAuth2/Storage/BaseTest.php
+++ b/test/lib/OAuth2/Storage/BaseTest.php
@@ -6,11 +6,25 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
 {
     public function provideStorage()
     {
-        $mysql = Bootstrap::getInstance()->getMysqlPdo();
-        $sqlite = Bootstrap::getInstance()->getSqlitePdo();
-        $mongo = Bootstrap::getInstance()->getMongo();
-        $redis = Bootstrap::getInstance()->getRedisStorage();
-        $cassandra = Bootstrap::getInstance()->getCassandraStorage();
+        if (!$mysql = Bootstrap::getInstance()->getMysqlPdo()) {
+            $mysql = new NullStorage('MySQL');
+        }
+
+        if (!$sqlite = Bootstrap::getInstance()->getSqlitePdo()) {
+            $sqlite = new NullStorage('SQLite');
+        }
+
+        if (!$mongo = Bootstrap::getInstance()->getMongo()) {
+            $mongo = new NullStorage('MongoDB');
+        }
+
+        if (!$redis = Bootstrap::getInstance()->getRedisStorage()) {
+            $redis = new NullStorage('Redis');
+        }
+
+        if (!$cassandra = Bootstrap::getInstance()->getCassandraStorage()) {
+            $cassandra = new NullStorage('Cassandra');
+        }
 
         /* hack until we can fix "default_scope" dependencies in other tests */
         // $memory = Bootstrap::getInstance()->getMemoryStorage();

--- a/test/lib/OAuth2/Storage/NullStorage.php
+++ b/test/lib/OAuth2/Storage/NullStorage.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace OAuth2\Storage;
+
+/**
+*
+*/
+class NullStorage extends Memory
+{
+    private $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    public function __toString()
+    {
+        return $this->name;
+    }
+}


### PR DESCRIPTION
returns `Skipped Storage: XXX` when a storage engine is not loaded.  For instance:

```
Brents-MacBook-Pro-2:oauth2-server-php brentshaffer$ phpunit -v
PHPUnit 3.7.28 by Sebastian Bergmann.

Configuration read from /Library/WebServer/oauth2-server-php/phpunit.xml

...............................................................  63 / 221 ( 28%)
............................................................... 126 / 221 ( 57%)
............SSS...SSS...SSS...SSS...SSS...SSS...SSS...SSS...... 189 / 221 ( 85%)
...SSS...SSS...SSS...SSS...SSS..

Time: 2.13 seconds, Memory: 12.50Mb

There were 39 skipped tests:

1) OAuth2\Storage\AccessTokenTest::testSetAccessToken with data set #3 (MongoDB)
Skipped Storage: MongoDB

/Library/WebServer/oauth2-server-php/test/OAuth2/Storage/AccessTokenTest.php:11

2) OAuth2\Storage\AccessTokenTest::testSetAccessToken with data set #4 (Redis)
Skipped Storage: Redis

/Library/WebServer/oauth2-server-php/test/OAuth2/Storage/AccessTokenTest.php:11

3) OAuth2\Storage\AccessTokenTest::testSetAccessToken with data set #5 (Cassandra)
Skipped Storage: Cassandra

# ...

39) OAuth2\Storage\UserCredentialsTest::testCheckUserCredentials with data set #5 (Cassandra)
Skipped Storage: Cassandra

/Library/WebServer/oauth2-server-php/test/OAuth2/Storage/UserCredentialsTest.php:11
OK, but incomplete or skipped tests!
Tests: 221, Assertions: 720, Skipped: 39.
```
