### PR TITLE
Improve crypto token DX

### DIFF
--- a/src/OAuth2/Server.php
+++ b/src/OAuth2/Server.php
@@ -111,14 +111,8 @@ class Server implements ResourceControllerInterface,
         foreach ($storage as $key => $service) {
             $this->addStorage($service, $key);
         }
-
-        if (!empty($this->config['use_crypto_tokens']) && isset($this->storages['public_key'])) {
-            $tokenStorage = null;
-            if (!empty($this->config['store_encrypted_token_string']) && isset($this->storages['access_token'])) {
-                $tokenStorage = $this->storages['access_token'];
-            }
-            // wrap the access token storage as required.
-            $this->storages['access_token'] = new CryptoTokenStorage($this->storages['public_key'], $tokenStorage);
+        if (!empty($this->config['use_crypto_tokens'])) {
+            $this->createDefaultCryptoTokenStorage();
         }
 
         foreach ($grantTypes as $key => $grantType) {
@@ -345,6 +339,19 @@ class Server implements ResourceControllerInterface,
                 throw new \InvalidArgumentException(sprintf('storage of class "%s" must implement one of [%s]', get_class($storage), implode(', ', $this->storageMap)));
             }
         }
+    }
+
+    protected function createDefaultCryptoTokenStorage()
+    {
+        if (!isset($this->storages['public_key'])) {
+            throw new \LogicException("You must supply a storage object implementing OAuth2\Storage\PublicKeyInterface to use crypto tokens");
+        }
+        $tokenStorage = null;
+        if (!empty($this->config['store_encrypted_token_string']) && isset($this->storages['access_token'])) {
+            $tokenStorage = $this->storages['access_token'];
+        }
+        // wrap the access token storage as required.
+        $this->storages['access_token'] = new CryptoTokenStorage($this->storages['public_key'], $tokenStorage);
     }
 
     public function addResponseType(ResponseTypeInterface $responseType, $key = null)


### PR DESCRIPTION
Crypto tokens have bad DX. Previously I could initialize the server with my storage and I would be ready to serve requests. But if I want to support crypto tokens, I suddenly need to add a ton of boilerplate (and it's not even enough, compared to what the PR does):

``` diff
function oauth2_server_start($server = NULL) {
   $storage = new Drupal\oauth2_server\Storage();
+  $storage_list = array(
+    'access_token' => $storage,
+    'authorization_code' => $storage,
+    'client_credentials' => $storage,
+    'client' => $storage,
+    'refresh_token' => $storage,
+    'user_credentials' => $storage,
+    'jwt_bearer' => $storage,
+  );
   $grant_types = oauth2_server_grant_types();
+
   if ($server) {
-    $oauth2_server = new OAuth2\Server($storage, $server->settings);
-    // Initialize the scope util.
+    $response_types = array(
+      'token' => new OAuth2\ResponseType\AccessToken($storage, $storage, $server->settings),
+      'code' => new OAuth2\ResponseType\AuthorizationCode($storage, $server->settings),
+    );
+    // Wrap the storage if crypto tokens should be used.
+    if (!empty($server->settings['use_crypto_tokens'])) {
+      $storage_list['access_token'] = new OAuth2\Storage\CryptoToken($storage, $storage);
+      $response_types['token'] = new OAuth2\ResponseType\CryptoToken($storage);
+    }
+    // Initialize the server and add the scope util.
+    $oauth2_server = new OAuth2\Server($storage_list, $server->settings, array(), $response_types);
```

It feels better to have a "use_crypto_tokens" setting that would do the work for me.
