### PR TITLE
last refactoring of tests provides reason the tests are failing

### DIFF
--- a/src/OAuth2/Storage/Memory.php
+++ b/src/OAuth2/Storage/Memory.php
@@ -19,16 +19,16 @@ class Memory implements AuthorizationCodeInterface,
     ScopeInterface,
     PublicKeyInterface
 {
-    private $authorizationCodes;
-    private $userCredentials;
-    private $clientCredentials;
-    private $refreshTokens;
-    private $accessTokens;
-    private $jwt;
-    private $jti;
-    private $supportedScopes;
-    private $defaultScope;
-    private $keys;
+    public $authorizationCodes;
+    public $userCredentials;
+    public $clientCredentials;
+    public $refreshTokens;
+    public $accessTokens;
+    public $jwt;
+    public $jti;
+    public $supportedScopes;
+    public $defaultScope;
+    public $keys;
 
     public function __construct($params = array())
     {

--- a/test/OAuth2/Storage/AccessTokenTest.php
+++ b/test/OAuth2/Storage/AccessTokenTest.php
@@ -5,10 +5,10 @@ namespace OAuth2\Storage;
 class AccessTokenTest extends BaseTest
 {
     /** @dataProvider provideStorage */
-    public function testSetAccessToken(AccessTokenInterface $storage = null)
+    public function testSetAccessToken(AccessTokenInterface $storage)
     {
         if ($storage instanceof NullStorage) {
-            $this->markTestSkipped('Skipped Storage: ' . $storage);
+            $this->markTestSkipped('Skipped Storage: ' . $storage->getMessage());
 
             return;
         }

--- a/test/OAuth2/Storage/AuthorizationCodeTest.php
+++ b/test/OAuth2/Storage/AuthorizationCodeTest.php
@@ -5,10 +5,10 @@ namespace OAuth2\Storage;
 class AuthorizationCodeTest extends BaseTest
 {
     /** @dataProvider provideStorage */
-    public function testGetAuthorizationCode(AuthorizationCodeInterface $storage = null)
+    public function testGetAuthorizationCode(AuthorizationCodeInterface $storage)
     {
         if ($storage instanceof NullStorage) {
-            $this->markTestSkipped('Skipped Storage: ' . $storage);
+            $this->markTestSkipped('Skipped Storage: ' . $storage->getMessage());
 
             return;
         }
@@ -23,10 +23,10 @@ class AuthorizationCodeTest extends BaseTest
     }
 
     /** @dataProvider provideStorage */
-    public function testSetAuthorizationCode(AuthorizationCodeInterface $storage = null)
+    public function testSetAuthorizationCode(AuthorizationCodeInterface $storage)
     {
         if ($storage instanceof NullStorage) {
-            $this->markTestSkipped('Skipped Storage: ' . $storage);
+            $this->markTestSkipped('Skipped Storage: ' . $storage->getMessage());
 
             return;
         }

--- a/test/OAuth2/Storage/ClientCredentialsTest.php
+++ b/test/OAuth2/Storage/ClientCredentialsTest.php
@@ -5,10 +5,10 @@ namespace OAuth2\Storage;
 class ClientCredentialsTest extends BaseTest
 {
     /** @dataProvider provideStorage */
-    public function testCheckClientCredentials(ClientCredentialsInterface $storage = null)
+    public function testCheckClientCredentials(ClientCredentialsInterface $storage)
     {
         if ($storage instanceof NullStorage) {
-            $this->markTestSkipped('Skipped Storage: ' . $storage);
+            $this->markTestSkipped('Skipped Storage: ' . $storage->getMessage());
 
             return;
         }

--- a/test/OAuth2/Storage/ClientTest.php
+++ b/test/OAuth2/Storage/ClientTest.php
@@ -5,10 +5,10 @@ namespace OAuth2\Storage;
 class ClientTest extends BaseTest
 {
     /** @dataProvider provideStorage */
-    public function testGetClientDetails(ClientInterface $storage = null)
+    public function testGetClientDetails(ClientInterface $storage)
     {
         if ($storage instanceof NullStorage) {
-            $this->markTestSkipped('Skipped Storage: ' . $storage);
+            $this->markTestSkipped('Skipped Storage: ' . $storage->getMessage());
 
             return;
         }
@@ -26,10 +26,10 @@ class ClientTest extends BaseTest
     }
 
     /** @dataProvider provideStorage */
-    public function testCheckRestrictedGrantType(ClientInterface $storage = null)
+    public function testCheckRestrictedGrantType(ClientInterface $storage)
     {
         if ($storage instanceof NullStorage) {
-            $this->markTestSkipped('Skipped Storage: ' . $storage);
+            $this->markTestSkipped('Skipped Storage: ' . $storage->getMessage());
 
             return;
         }
@@ -44,10 +44,10 @@ class ClientTest extends BaseTest
     }
 
     /** @dataProvider provideStorage */
-    public function testGetAccessToken(ClientInterface $storage = null)
+    public function testGetAccessToken(ClientInterface $storage)
     {
         if ($storage instanceof NullStorage) {
-            $this->markTestSkipped('Skipped Storage: ' . $storage);
+            $this->markTestSkipped('Skipped Storage: ' . $storage->getMessage());
 
             return;
         }
@@ -62,10 +62,10 @@ class ClientTest extends BaseTest
     }
 
     /** @dataProvider provideStorage */
-    public function testSaveClient(ClientInterface $storage = null)
+    public function testSaveClient(ClientInterface $storage)
     {
         if ($storage instanceof NullStorage) {
-            $this->markTestSkipped('Skipped Storage: ' . $storage);
+            $this->markTestSkipped('Skipped Storage: ' . $storage->getMessage());
 
             return;
         }

--- a/test/OAuth2/Storage/PublicKeyTest.php
+++ b/test/OAuth2/Storage/PublicKeyTest.php
@@ -8,7 +8,7 @@ class PublicKeyTest extends BaseTest
     public function testSetAccessToken($storage)
     {
         if ($storage instanceof NullStorage) {
-            $this->markTestSkipped('Skipped Storage: ' . $storage);
+            $this->markTestSkipped('Skipped Storage: ' . $storage->getMessage());
 
             return;
         }

--- a/test/OAuth2/Storage/RefreshTokenTest.php
+++ b/test/OAuth2/Storage/RefreshTokenTest.php
@@ -5,10 +5,10 @@ namespace OAuth2\Storage;
 class RefreshTokenTest extends BaseTest
 {
     /** @dataProvider provideStorage */
-    public function testSetRefreshToken(RefreshTokenInterface $storage = null)
+    public function testSetRefreshToken(RefreshTokenInterface $storage)
     {
         if ($storage instanceof NullStorage) {
-            $this->markTestSkipped('Skipped Storage: ' . $storage);
+            $this->markTestSkipped('Skipped Storage: ' . $storage->getMessage());
 
             return;
         }

--- a/test/OAuth2/Storage/ScopeTest.php
+++ b/test/OAuth2/Storage/ScopeTest.php
@@ -7,10 +7,10 @@ use OAuth2\Scope;
 class ScopeTest extends BaseTest
 {
     /** @dataProvider provideStorage */
-    public function testScopeExists($storage = null)
+    public function testScopeExists($storage)
     {
         if ($storage instanceof NullStorage) {
-            $this->markTestSkipped('Skipped Storage: ' . $storage);
+            $this->markTestSkipped('Skipped Storage: ' . $storage->getMessage());
 
             return;
         }
@@ -29,10 +29,10 @@ class ScopeTest extends BaseTest
     }
 
     /** @dataProvider provideStorage */
-    public function testGetDefaultScope($storage = null)
+    public function testGetDefaultScope($storage)
     {
         if ($storage instanceof NullStorage) {
-            $this->markTestSkipped('Skipped Storage: ' . $storage);
+            $this->markTestSkipped('Skipped Storage: ' . $storage->getMessage());
 
             return;
         }

--- a/test/OAuth2/Storage/UserCredentialsTest.php
+++ b/test/OAuth2/Storage/UserCredentialsTest.php
@@ -5,10 +5,10 @@ namespace OAuth2\Storage;
 class UserCredentialsTest extends BaseTest
 {
     /** @dataProvider provideStorage */
-    public function testCheckUserCredentials(UserCredentialsInterface $storage = null)
+    public function testCheckUserCredentials(UserCredentialsInterface $storage)
     {
         if ($storage instanceof NullStorage) {
-            $this->markTestSkipped('Skipped Storage: ' . $storage);
+            $this->markTestSkipped('Skipped Storage: ' . $storage->getMessage());
 
             return;
         }

--- a/test/lib/OAuth2/Storage/BaseTest.php
+++ b/test/lib/OAuth2/Storage/BaseTest.php
@@ -6,33 +6,16 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
 {
     public function provideStorage()
     {
-        if (!$mysql = Bootstrap::getInstance()->getMysqlPdo()) {
-            $mysql = new NullStorage('MySQL');
-        }
-
-        if (!$sqlite = Bootstrap::getInstance()->getSqlitePdo()) {
-            $sqlite = new NullStorage('SQLite');
-        }
-
-        if (!$mongo = Bootstrap::getInstance()->getMongo()) {
-            $mongo = new NullStorage('MongoDB');
-        }
-
-        if (!$redis = Bootstrap::getInstance()->getRedisStorage()) {
-            $redis = new NullStorage('Redis');
-        }
-
-        if (!$cassandra = Bootstrap::getInstance()->getCassandraStorage()) {
-            $cassandra = new NullStorage('Cassandra');
-        }
+        $mysql = Bootstrap::getInstance()->getMysqlPdo();
+        $sqlite = Bootstrap::getInstance()->getSqlitePdo();
+        $mongo = Bootstrap::getInstance()->getMongo();
+        $redis = Bootstrap::getInstance()->getRedisStorage();
+        $cassandra = Bootstrap::getInstance()->getCassandraStorage();
+        $memory = Bootstrap::getInstance()->getMemoryStorage();
 
         /* hack until we can fix "default_scope" dependencies in other tests */
-        // $memory = Bootstrap::getInstance()->getMemoryStorage();
-        $memoryConfig = json_decode(file_get_contents(__DIR__.'/../../../config/storage.json'), true);
-        $memoryConfig['default_scope'] = 'defaultscope1 defaultscope2';
-        $memory = new Memory($memoryConfig);
+        $memory->defaultScope = 'defaultscope1 defaultscope2';
 
-        // will add multiple storage types later
         return array(
             array($memory),
             array($sqlite),

--- a/test/lib/OAuth2/Storage/Bootstrap.php
+++ b/test/lib/OAuth2/Storage/Bootstrap.php
@@ -54,7 +54,11 @@ class Bootstrap
                     $redis->flushdb();
                     $this->redis = new Redis($redis);
                     $this->createRedisDb($this->redis);
+                } else {
+                    $this->redis = new NullStorage('Redis', 'Unable to connect to redis server on port 6379');
                 }
+            } else {
+                $this->redis = new NullStorage('Redis', 'Missing redis library. Please run "composer.phar require predis/predis:dev-master"');
             }
         }
 
@@ -99,7 +103,11 @@ class Bootstrap
                     $this->createMongoDb($db);
 
                     $this->mongo = new Mongo($db);
+                } else {
+                    $this->mongo = new NullStorage('Mongo', 'Unable to connect to mongo server on "localhost:27017"');
                 }
+            } else {
+                $this->mongo = new NullStorage('Mongo', 'Missing mongo php extension. Please install mongo.so');
             }
         }
 
@@ -126,9 +134,12 @@ class Bootstrap
                     $this->removeCassandraDb();
                     $this->cassandra = new Cassandra($cassandra);
                     $this->createCassandraDb($this->cassandra);
+                } else {
+                    $this->cassandra = new NullStorage('Cassandra', 'Unable to connect to cassandra server on "127.0.0.1:9160"');
                 }
+            } else {
+                $this->cassandra = new NullStorage('Cassandra', 'Missing cassandra library. Please run "composer.phar require thobbs/phpcassa:dev-master"');
             }
-
         }
 
         return $this->cassandra;

--- a/test/lib/OAuth2/Storage/NullStorage.php
+++ b/test/lib/OAuth2/Storage/NullStorage.php
@@ -8,14 +8,25 @@ namespace OAuth2\Storage;
 class NullStorage extends Memory
 {
     private $name;
+    private $description;
 
-    public function __construct($name)
+    public function __construct($name, $description = null)
     {
         $this->name = $name;
+        $this->description = $description;
     }
 
     public function __toString()
     {
+        return $this->name;
+    }
+
+    public function getMessage()
+    {
+        if ($this->description) {
+             return $this->description;
+        }
+
         return $this->name;
     }
 }


### PR DESCRIPTION
Provides nice output such as:

``` text
1) OAuth2\Storage\ClientTest::testGetClientDetails with data set #5 (Cassandra)
Skipped Storage: Unable to connect to cassandra server on "127.0.0.1:9160"

2) OAuth2\Storage\PublicKeyTest::testSetAccessToken with data set #5 (Cassandra)
Skipped Storage: Missing cassandra library. Please run "composer.phar require thobbs/phpcassa:dev-master"

3) OAuth2\Storage\ClientTest::testSaveClient with data set #3 (Mongo)
Skipped Storage: Unable to connect to mongo server on "localhost:27017"

4) OAuth2\Storage\RefreshTokenTest::testSetRefreshToken with data set #3 (Mongo)
Skipped Storage: Missing mongo php extension. Please install mongo.so

5) OAuth2\Storage\AccessTokenTest::testSetAccessToken with data set #4 (Redis)
Skipped Storage: Unable to connect to redis server on port 6379

6) OAuth2\Storage\UserCredentialsTest::testCheckUserCredentials with data set #4 (Redis)
Skipped Storage: Missing redis library. Please run "composer require predis/predis:dev-master"
```

This should help contributors be able to run the test suite and determine why tests are being skipped
