### PR TITLE
Fixed Redis delete command

### DIFF
--- a/src/OAuth2/Storage/Redis.php
+++ b/src/OAuth2/Storage/Redis.php
@@ -83,7 +83,7 @@ class Redis implements AuthorizationCodeInterface,
     {
         unset($this->cache[$key]);
 
-        return $this->redis->delete($key);
+        return $this->redis->del($key);
     }
 
     /* AuthorizationCodeInterface */


### PR DESCRIPTION
\Predis\Client uses #del instead of #delete.
