### PR TITLE
removes  requirement from built-in storages

### DIFF
--- a/src/OAuth2/Storage/Cassandra.php
+++ b/src/OAuth2/Storage/Cassandra.php
@@ -314,24 +314,20 @@ class Cassandra implements AuthorizationCodeInterface,
     }
 
     /*JWTBearerInterface */
-    public function getClientKey($client_id, $subject)
+    public function getClientKey($client_id, $subject = null)
     {
         if (!$jwt = $this->getValue($this->config['jwt_key'] . $client_id)) {
             return false;
         }
 
-        if (isset($jwt['subject']) && $jwt['subject'] == $subject ) {
-            return $jwt['key'];
-        }
-
-        return null;
+        return $jwt['public_key'];
     }
 
     public function setClientKey($client_id, $key, $subject = null)
     {
         return $this->setValue($this->config['jwt_key'] . $client_id, array(
-            'key' => $key,
-            'subject' => $subject
+            'public_key' => $key,
+            'subject'    => $subject
         ));
     }
 

--- a/src/OAuth2/Storage/Memory.php
+++ b/src/OAuth2/Storage/Memory.php
@@ -226,15 +226,14 @@ class Memory implements AuthorizationCodeInterface,
     }
 
     /*JWTBearerInterface */
-    public function getClientKey($client_id, $subject)
+    public function getClientKey($client_id, $subject = null)
     {
         if (isset($this->jwt[$client_id])) {
-            $jwt = $this->jwt[$client_id];
-            if ($jwt) {
-                if ($jwt["subject"] == $subject) {
-                    return $jwt["key"];
-                }
+            if (!$jwt = $this->jwt[$client_id]) {
+                return false;
             }
+
+            return $jwt['public_key'];
         }
 
         return false;

--- a/src/OAuth2/Storage/Mongo.php
+++ b/src/OAuth2/Storage/Mongo.php
@@ -297,14 +297,11 @@ class Mongo implements AuthorizationCodeInterface,
         return true;
     }
 
-    public function getClientKey($client_id, $subject)
+    public function getClientKey($client_id, $subject = null)
     {
-        $result = $this->collection('jwt_table')->findOne(array(
-            'client_id' => $client_id,
-            'subject' => $subject
-        ));
+        $result = $this->collection('jwt_table')->findOne(array('client_id' => $client_id));
 
-        return is_null($result) ? false : $result['key'];
+        return is_null($result) ? false : $result['public_key'];
     }
 
     public function getClientScope($client_id)

--- a/src/OAuth2/Storage/Pdo.php
+++ b/src/OAuth2/Storage/Pdo.php
@@ -294,11 +294,13 @@ class Pdo implements AuthorizationCodeInterface,
     }
 
     /* JWTBearerInterface */
-    public function getClientKey($client_id, $subject)
+    public function getClientKey($client_id, $subject = null)
     {
-        $stmt = $this->db->prepare($sql = sprintf('SELECT public_key from %s where client_id=:client_id AND subject=:subject', $this->config['jwt_table']));
+        $sql = sprintf('SELECT public_key from %s where client_id=:client_id', $this->config['jwt_table']);
 
-        $stmt->execute(array('client_id' => $client_id, 'subject' => $subject));
+        $stmt = $this->db->prepare($sql);
+
+        $stmt->execute(array('client_id' => $client_id));
 
         return $stmt->fetchColumn();
     }

--- a/src/OAuth2/Storage/Redis.php
+++ b/src/OAuth2/Storage/Redis.php
@@ -261,24 +261,19 @@ class Redis implements AuthorizationCodeInterface,
     }
 
     /*JWTBearerInterface */
-    public function getClientKey($client_id, $subject)
+    public function getClientKey($client_id, $subject = null)
     {
         if (!$jwt = $this->getValue($this->config['jwt_key'] . $client_id)) {
             return false;
         }
 
-        if (isset($jwt['subject']) && $jwt['subject'] == $subject) {
-            return $jwt['key'];
-        }
-
-        return null;
+        return $jwt['public_key'];
     }
 
-    public function setClientKey($client_id, $key, $subject = null)
+    public function setClientKey($client_id, $key)
     {
         return $this->setValue($this->config['jwt_key'] . $client_id, array(
-            'key' => $key,
-            'subject' => $subject
+            'public_key' => $key
         ));
     }
 

--- a/test/OAuth2/GrantType/JWTBearerTest.php
+++ b/test/OAuth2/GrantType/JWTBearerTest.php
@@ -189,21 +189,6 @@ EOD;
         $this->assertEquals($response->getParameter('error_description'), 'Invalid issuer (iss) or subject (sub) provided');
     }
 
-    public function testBadSubject()
-    {
-        $server = $this->getTestServer();
-        $request = TestRequest::createPost(array(
-            'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',  // valid grant type
-            'assertion' => $this->getJWT(null, null, 'anotheruser@ourdomain,com'),
-        ));
-
-        $server->grantAccessToken($request, $response = new Response());
-
-        $this->assertEquals($response->getStatusCode(), 400);
-        $this->assertEquals($response->getParameter('error'), 'invalid_grant');
-        $this->assertEquals($response->getParameter('error_description'), 'Invalid issuer (iss) or subject (sub) provided');
-    }
-
     public function testMissingKey()
     {
         $server = $this->getTestServer();

--- a/test/OAuth2/Storage/JwtBearerTest.php
+++ b/test/OAuth2/Storage/JwtBearerTest.php
@@ -17,8 +17,8 @@ class JwtBearerTest extends BaseTest
         $key = $storage->getClientKey('this-is-not-real', 'nor-is-this');
         $this->assertFalse($key);
 
-        // valid client_id and subject
-        $key = $storage->getClientKey('oauth_test_client', 'test_subject');
+        // valid client_id
+        $key = $storage->getClientKey('oauth_test_client');
         $this->assertNotNull($key);
         $this->assertEquals($key, Bootstrap::getInstance()->getTestPublicKey());
     }

--- a/test/config/storage.json
+++ b/test/config/storage.json
@@ -109,23 +109,23 @@
     },
     "jwt": {
         "Test Client ID": {
-            "key": "-----BEGIN PUBLIC KEY-----\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC5/SxVlE8gnpFqCxgl2wjhzY7u\ncEi00s0kUg3xp7lVEvgLgYcAnHiWp+gtSjOFfH2zsvpiWm6Lz5f743j/FEzHIO1o\nwR0p4d9pOaJK07d01+RzoQLOIQAgXrr4T1CCWUesncwwPBVCyy2Mw3Nmhmr9MrF8\nUlvdRKBxriRnlP3qJQIDAQAB\n-----END PUBLIC KEY-----",
+            "public_key": "-----BEGIN PUBLIC KEY-----\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC5/SxVlE8gnpFqCxgl2wjhzY7u\ncEi00s0kUg3xp7lVEvgLgYcAnHiWp+gtSjOFfH2zsvpiWm6Lz5f743j/FEzHIO1o\nwR0p4d9pOaJK07d01+RzoQLOIQAgXrr4T1CCWUesncwwPBVCyy2Mw3Nmhmr9MrF8\nUlvdRKBxriRnlP3qJQIDAQAB\n-----END PUBLIC KEY-----",
             "subject": "testuser@ourdomain.com"
         },
         "Test Client ID PHP-5.2": {
-            "key": "mysecretkey",
+            "public_key": "mysecretkey",
             "subject": "testuser@ourdomain.com"
         },
         "Missing Key Client": {
-            "key": null,
+            "public_key": null,
             "subject": "testuser@ourdomain.com"
         },
         "Missing Key Client PHP-5.2": {
-            "key": null,
+            "public_key": null,
             "subject": "testuser@ourdomain.com"
         },
         "oauth_test_client": {
-            "key": "-----BEGIN CERTIFICATE-----\nMIICiDCCAfGgAwIBAgIBADANBgkqhkiG9w0BAQQFADA9MQswCQYDVQQGEwJVUzEL\nMAkGA1UECBMCVVQxITAfBgNVBAoTGFZpZ25ldHRlIENvcnBvcmF0aW9uIFNCWDAe\nFw0xMTEwMTUwMzE4MjdaFw0zMTEwMTAwMzE4MjdaMD0xCzAJBgNVBAYTAlVTMQsw\nCQYDVQQIEwJVVDEhMB8GA1UEChMYVmlnbmV0dGUgQ29ycG9yYXRpb24gU0JYMIGf\nMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC8fpi06NfVYHAOAnxNMVnTXr/ptsLs\nNjP+uAt2eO0cc5J9H5XV8lFVujOrRu/JWi1TDmAvOaf/6A3BphIA1Pwp0AAqlZdw\nizIum8j0KzpsGYH5qReNQDwF3oUSKMsQCCGCDHrDYifG/pRi9bN1ZVjEXPr35HJu\nBe+FQpZTs8DewwIDAQABo4GXMIGUMB0GA1UdDgQWBBRe8hrEXm+Yim4YlD5Nx+1K\nvCYs9DBlBgNVHSMEXjBcgBRe8hrEXm+Yim4YlD5Nx+1KvCYs9KFBpD8wPTELMAkG\nA1UEBhMCVVMxCzAJBgNVBAgTAlVUMSEwHwYDVQQKExhWaWduZXR0ZSBDb3Jwb3Jh\ndGlvbiBTQliCAQAwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQQFAAOBgQBjhyRD\nlM7vnLn6drgQVftW5V9nDFAyPAuiGvMIKFSbiAf1PxXCRn5sfJquwWKsJUi4ZGNl\naViXdFmN6/F13PSM+yg63tpKy0fYqMbTM+Oe5WuSHkSW1VuYNHV+24adgNk/FRDL\nFRrlM1f6s9VTLWvwGItjfrof0Ba8Uq7ZDSb9Xg==\n-----END CERTIFICATE-----",
+            "public_key": "-----BEGIN CERTIFICATE-----\nMIICiDCCAfGgAwIBAgIBADANBgkqhkiG9w0BAQQFADA9MQswCQYDVQQGEwJVUzEL\nMAkGA1UECBMCVVQxITAfBgNVBAoTGFZpZ25ldHRlIENvcnBvcmF0aW9uIFNCWDAe\nFw0xMTEwMTUwMzE4MjdaFw0zMTEwMTAwMzE4MjdaMD0xCzAJBgNVBAYTAlVTMQsw\nCQYDVQQIEwJVVDEhMB8GA1UEChMYVmlnbmV0dGUgQ29ycG9yYXRpb24gU0JYMIGf\nMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC8fpi06NfVYHAOAnxNMVnTXr/ptsLs\nNjP+uAt2eO0cc5J9H5XV8lFVujOrRu/JWi1TDmAvOaf/6A3BphIA1Pwp0AAqlZdw\nizIum8j0KzpsGYH5qReNQDwF3oUSKMsQCCGCDHrDYifG/pRi9bN1ZVjEXPr35HJu\nBe+FQpZTs8DewwIDAQABo4GXMIGUMB0GA1UdDgQWBBRe8hrEXm+Yim4YlD5Nx+1K\nvCYs9DBlBgNVHSMEXjBcgBRe8hrEXm+Yim4YlD5Nx+1KvCYs9KFBpD8wPTELMAkG\nA1UEBhMCVVMxCzAJBgNVBAgTAlVUMSEwHwYDVQQKExhWaWduZXR0ZSBDb3Jwb3Jh\ndGlvbiBTQliCAQAwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQQFAAOBgQBjhyRD\nlM7vnLn6drgQVftW5V9nDFAyPAuiGvMIKFSbiAf1PxXCRn5sfJquwWKsJUi4ZGNl\naViXdFmN6/F13PSM+yg63tpKy0fYqMbTM+Oe5WuSHkSW1VuYNHV+24adgNk/FRDL\nFRrlM1f6s9VTLWvwGItjfrof0Ba8Uq7ZDSb9Xg==\n-----END CERTIFICATE-----",
             "subject": "test_subject"
         }
     },

--- a/test/lib/OAuth2/Storage/Bootstrap.php
+++ b/test/lib/OAuth2/Storage/Bootstrap.php
@@ -298,9 +298,9 @@ class Bootstrap
         ));
 
         $db->oauth_jwt->insert(array(
-            'client_id' => 'oauth_test_client',
-            'key'       => $this->getTestPublicKey(),
-            'subject'   => 'test_subject',
+            'client_id'  => 'oauth_test_client',
+            'public_key' => $this->getTestPublicKey(),
+            'subject'    => 'test_subject',
         ));
     }
 


### PR DESCRIPTION
I am not sure we need the client to upload a public key per user (i.e. `subject`)... this is a lot of overhead. 

This PR will break BC for built-in-storages, but it may be worth it in order to make JWTBearer less complicated
