### PR TITLE
Silence open_basedir error on file_exists

### DIFF
--- a/src/OAuth2/ResponseType/AuthorizationCode.php
+++ b/src/OAuth2/ResponseType/AuthorizationCode.php
@@ -85,7 +85,7 @@ class AuthorizationCode implements AuthorizationCodeInterface
     protected function generateAuthorizationCode()
     {
         $tokenLen = 40;
-        if (file_exists('/dev/urandom')) { // Get 100 bytes of random data
+        if (@file_exists('/dev/urandom')) { // Get 100 bytes of random data
             $randomData = file_get_contents('/dev/urandom', false, null, 0, 100) . uniqid(mt_rand(), true);
         } else {
             $randomData = mt_rand() . mt_rand() . mt_rand() . mt_rand() . microtime(true) . uniqid(mt_rand(), true);


### PR DESCRIPTION
This silences an open_basedir error. Related to #227
