### PR TITLE
Added `getQuerystringIdentifier()` to the GrantType interface

### DIFF
--- a/src/OAuth2/GrantType/GrantTypeInterface.php
+++ b/src/OAuth2/GrantType/GrantTypeInterface.php
@@ -11,6 +11,7 @@ use OAuth2\ResponseInterface;
  */
 interface GrantTypeInterface
 {
+    public function getQuerystringIdentifier();
     public function validateRequest(RequestInterface $request, ResponseInterface $response);
     public function getClientId();
     public function getUserId();


### PR DESCRIPTION
The `TokenController` calls `getQuerystringIdentifier()` on each grant type, and the `GrantTypeInterface` doesn't enforce that the function exists, causing a fatal error when using a custom defined Grant Type.
