### PR TITLE
Use mcrypt_create_iv or openssl_random_pseudo_bytes as random bytes source

### DIFF
--- a/src/OAuth2/ResponseType/AccessToken.php
+++ b/src/OAuth2/ResponseType/AccessToken.php
@@ -122,7 +122,11 @@ class AccessToken implements AccessTokenInterface
     protected function generateAccessToken()
     {
         $tokenLen = 40;
-        if (@file_exists('/dev/urandom')) { // Get 100 bytes of random data
+        if (function_exists('mcrypt_create_iv')) {
+            $randomData = mcrypt_create_iv(100, MCRYPT_DEV_URANDOM);
+        } else if (function_exists('openssl_random_pseudo_bytes')) {
+            $randomData = openssl_random_pseudo_bytes(100);
+        } else if (@file_exists('/dev/urandom')) { // Get 100 bytes of random data
             $randomData = file_get_contents('/dev/urandom', false, null, 0, 100) . uniqid(mt_rand(), true);
         } else {
             $randomData = mt_rand() . mt_rand() . mt_rand() . mt_rand() . microtime(true) . uniqid(mt_rand(), true);

--- a/src/OAuth2/ResponseType/AuthorizationCode.php
+++ b/src/OAuth2/ResponseType/AuthorizationCode.php
@@ -85,7 +85,11 @@ class AuthorizationCode implements AuthorizationCodeInterface
     protected function generateAuthorizationCode()
     {
         $tokenLen = 40;
-        if (@file_exists('/dev/urandom')) { // Get 100 bytes of random data
+        if (function_exists('mcrypt_create_iv')) {
+            $randomData = mcrypt_create_iv(100, MCRYPT_DEV_URANDOM);
+        } else if (function_exists('openssl_random_pseudo_bytes')) {
+            $randomData = openssl_random_pseudo_bytes(100);
+        } else if (@file_exists('/dev/urandom')) { // Get 100 bytes of random data
             $randomData = file_get_contents('/dev/urandom', false, null, 0, 100) . uniqid(mt_rand(), true);
         } else {
             $randomData = mt_rand() . mt_rand() . mt_rand() . mt_rand() . microtime(true) . uniqid(mt_rand(), true);


### PR DESCRIPTION
Currently OAuth2 server uses `/dev/urandom` and fallbacks to `mt_rand()`.

`/dev/urandom` is good source of random data, however with `open_basedir` restriction in effect it throws warning. Suppressing it with `@` doesn't display warning, but error handler still gets called.

`mcrypt_create_iv` allows read bytes from `/dev/urandom` even with `open_basedir`, also supports Windows.

Based on Password Compat
https://github.com/ircmaxell/password_compat/blob/master/lib/password.php#L93
