### PR TITLE
Allow "Authorization" as well as "AUTHORIZATION" for TokenType\Bearer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # Test Files #
 test/config/test.sqlite
 vendor
+composer.lock
+.idea

--- a/src/OAuth2/Request.php
+++ b/src/OAuth2/Request.php
@@ -80,7 +80,9 @@ class Request implements RequestInterface
 
     public function headers($name, $default = null)
     {
-        return isset($this->headers[$name]) ? $this->headers[$name] : $default;
+        $headers = array_change_key_case($this->headers);
+        $name = strtolower($name);
+        return isset($headers[$name]) ? $headers[$name] : $default;
     }
 
     public function getAllQueryParameters()

--- a/test/OAuth2/RequestTest.php
+++ b/test/OAuth2/RequestTest.php
@@ -36,6 +36,45 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNUll($response->getParameter('access_token'));
     }
 
+    public function testHeadersReturnsValueByKey()
+    {
+        $request = new Request(
+            array(),
+            array(),
+            array(),
+            array(),
+            array(),
+            array(),
+            array(),
+            array('AUTHORIZATION' => 'Basic secret')
+        );
+
+        $this->assertEquals('Basic secret', $request->headers('AUTHORIZATION'));
+    }
+
+    public function testHeadersReturnsDefaultIfHeaderNotPresent()
+    {
+        $request = new Request();
+
+        $this->assertEquals('Bearer', $request->headers('AUTHORIZATION', 'Bearer'));
+    }
+
+    public function testHeadersIsCaseInsensitive()
+    {
+        $request = new Request(
+            array(),
+            array(),
+            array(),
+            array(),
+            array(),
+            array(),
+            array(),
+            array('AUTHORIZATION' => 'Basic secret')
+        );
+
+        $this->assertEquals('Basic secret', $request->headers('Authorization'));
+    }
+
     private function getTestServer($config = array())
     {
         $storage = Bootstrap::getInstance()->getMemoryStorage();

--- a/test/OAuth2/TokenType/BearerTest.php
+++ b/test/OAuth2/TokenType/BearerTest.php
@@ -33,4 +33,26 @@ class BearerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($response->getParameter('error'), 'invalid_request');
         $this->assertEquals($response->getParameter('error_description'), 'The content type for POST requests must be "application/x-www-form-urlencoded"');
     }
+
+    public function testValidRequestUsingAuthorizationHeader()
+    {
+        $bearer = new Bearer();
+        $request = new TestRequest();
+        $request->headers['AUTHORIZATION'] = 'Bearer MyToken';
+        $request->server['CONTENT_TYPE'] = 'application/x-www-form-urlencoded; charset=UTF-8';
+
+        $param = $bearer->getAccessTokenParameter($request, $response = new Response());
+        $this->assertEquals('MyToken', $param);
+    }
+
+    public function testValidRequestUsingAuthorizationHeaderCaseInsensitive()
+    {
+        $bearer = new Bearer();
+        $request = new TestRequest();
+        $request->server['CONTENT_TYPE'] = 'application/x-www-form-urlencoded; charset=UTF-8';
+        $request->headers['Authorization'] = 'Bearer MyToken';
+
+        $param = $bearer->getAccessTokenParameter($request, $response = new Response());
+        $this->assertEquals('MyToken', $param);
+    }
 }

--- a/test/lib/OAuth2/Request/TestRequest.php
+++ b/test/lib/OAuth2/Request/TestRequest.php
@@ -2,12 +2,13 @@
 
 namespace OAuth2\Request;
 
+use OAuth2\Request;
 use OAuth2\RequestInterface;
 
 /**
 *
 */
-class TestRequest implements RequestInterface
+class TestRequest extends Request implements RequestInterface
 {
     public $query, $request, $server, $headers;
 
@@ -16,6 +17,7 @@ class TestRequest implements RequestInterface
         $this->query = $_GET;
         $this->request = $_POST;
         $this->server  = $_SERVER;
+        $this->headers = array();
     }
 
     public function query($name, $default = null)
@@ -31,11 +33,6 @@ class TestRequest implements RequestInterface
     public function server($name, $default = null)
     {
         return isset($this->server[$name]) ? $this->server[$name] : $default;
-    }
-
-    public function headers($name, $default = null)
-    {
-        return isset($this->headers[$name]) ? $this->headers[$name] : $default;
     }
 
     public function getAllQueryParameters()


### PR DESCRIPTION
When using an Authorization header, all caps is enforced. It would be nice to support the alternative as demonstrated in the OAuth2 RFC.

```
GET /resource/1 HTTP/1.1
Host: example.com
Authorization: Bearer mF_9.B5f-4.1JqM
```

This PR allows the current "AUTHORIZATION" key to be used, but also allows support for "Authorization". I also added phpunit as a require-dev key and added tests for using the Authorization header in both formats.
