### PR TITLE
Making auth_time configurable in OpenID Connect

### DIFF
--- a/src/OAuth2/OpenID/ResponseType/IdToken.php
+++ b/src/OAuth2/OpenID/ResponseType/IdToken.php
@@ -29,6 +29,7 @@ class IdToken implements IdTokenInterface
         }
         $this->config = array_merge(array(
             'id_lifetime' => 3600,
+            'id_auth_time' => null
         ), $config);
     }
 
@@ -57,7 +58,7 @@ class IdToken implements IdTokenInterface
             'aud'        => $client_id,
             'iat'        => time(),
             'exp'        => time() + $this->config['id_lifetime'],
-            'auth_time'  => time(),
+            'auth_time'  => $this->config['id_auth_time'] ?: time(),
         );
         if ($nonce) {
             $token['nonce'] = $nonce;

--- a/src/OAuth2/Server.php
+++ b/src/OAuth2/Server.php
@@ -116,6 +116,7 @@ class Server implements ResourceControllerInterface,
             'store_encrypted_token_string' => true,
             'use_openid_connect'       => false,
             'id_lifetime'              => 3600,
+            'id_auth_time'             => null,
             'access_lifetime'          => 3600,
             'www_realm'                => 'Service',
             'token_param_name'         => 'access_token',
@@ -718,7 +719,7 @@ class Server implements ResourceControllerInterface,
             throw new \LogicException("You must supply a storage object implementing OAuth2\Storage\PublicKeyInterface to use openid connect");
         }
 
-        $config = array_intersect_key($this->config, array_flip(explode(' ', 'issuer id_lifetime')));
+        $config = array_intersect_key($this->config, array_flip(explode(' ', 'issuer id_lifetime id_auth_time')));
         return new IdToken($this->storages['user_claims'], $this->storages['public_key'], $config);
     }
 


### PR DESCRIPTION
While trying to implement an OpenID Connect server with this lib, I stumbled upon an issue with auth_time not being configurable. The lib set auth_time to the current time, whereas it should be the time when the End-User authentication occured (according to OpenID Connect specs).

This pull request adds a config parameter "id_auth_time". When present, it'll be used in the ID Token instead of the current time. I'm not sure it's the right way to do it, but I didn't find any other solution to set the auth_time in my application.
