### PR TITLE
Add support for the OpenID Connect prompt parameter

### DIFF
--- a/src/OAuth2/Controller/AuthorizeController.php
+++ b/src/OAuth2/Controller/AuthorizeController.php
@@ -72,23 +72,20 @@ class AuthorizeController implements AuthorizeControllerInterface
             return;
         }
 
-        // If no redirect_uri is passed in the request, use client's registered one
-        if (empty($this->redirect_uri)) {
-            $clientData              = $this->clientStorage->getClientDetails($this->client_id);
-            $registered_redirect_uri = $clientData['redirect_uri'];
-        }
-
         // the user declined access to the client's application
         if ($is_authorized === false) {
-            $redirect_uri = $this->redirect_uri ?: $registered_redirect_uri;
-            $response->setRedirect($this->config['redirect_status_code'], $redirect_uri, $this->state, 'access_denied', "The user denied access to your application");
-
-            return;
+            return $this->setNotAuthorizedResponse($request, $response, $user_id);
         }
 
         // build the parameters to set in the redirect URI
         if (!$params = $this->buildAuthorizeParameters($request, $response, $user_id)) {
             return;
+        }
+
+        // If no redirect_uri is passed in the request, use client's registered one
+        if (empty($this->redirect_uri)) {
+            $clientData              = $this->clientStorage->getClientDetails($this->client_id);
+            $registered_redirect_uri = $clientData['redirect_uri'];
         }
 
         $authResult = $this->responseTypes[$this->response_type]->getAuthorizeResponse($params, $user_id);
@@ -103,6 +100,19 @@ class AuthorizeController implements AuthorizeControllerInterface
 
         // return redirect response
         $response->setRedirect($this->config['redirect_status_code'], $uri);
+    }
+
+    protected function setNotAuthorizedResponse(RequestInterface $request, ResponseInterface $response, $user_id = null)
+    {
+        // If no redirect_uri is passed in the request, use client's registered one
+        if (empty($this->redirect_uri)) {
+            $clientData              = $this->clientStorage->getClientDetails($this->client_id);
+            $registered_redirect_uri = $clientData['redirect_uri'];
+        }
+        $redirect_uri = $this->redirect_uri ?: $registered_redirect_uri;
+        $error = 'access_denied';
+        $error_message = 'The user denied access to your application';
+        $response->setRedirect($this->config['redirect_status_code'], $redirect_uri, $this->state, $error, $error_message);
     }
 
     /*

--- a/src/OAuth2/OpenID/Controller/AuthorizeController.php
+++ b/src/OAuth2/OpenID/Controller/AuthorizeController.php
@@ -13,47 +13,29 @@ class AuthorizeController extends BaseAuthorizeController implements AuthorizeCo
 {
     private $nonce;
 
-    public function handleAuthorizeRequest(RequestInterface $request, ResponseInterface $response, $is_authorized, $user_id = null)
+    protected function setNotAuthorizedResponse(RequestInterface $request, ResponseInterface $response, $user_id = null)
     {
-        if (!is_bool($is_authorized)) {
-            throw new \InvalidArgumentException('Argument "is_authorized" must be a boolean.  This method must know if the user has granted access to the client.');
-        }
-
-        // We repeat this, because we need to re-validate. The request could be POSTed
-        // by a 3rd-party (because we are not internally enforcing NONCEs, etc)
-        if (!$this->validateAuthorizeRequest($request, $response)) {
-            return;
-        }
-
         // If no redirect_uri is passed in the request, use client's registered one
         if (empty($this->redirect_uri)) {
             $clientData              = $this->clientStorage->getClientDetails($this->client_id);
             $registered_redirect_uri = $clientData['redirect_uri'];
         }
+        $redirect_uri = $this->redirect_uri ?: $registered_redirect_uri;
 
-        // the user declined access to the client's application
-        if ($is_authorized === false) {
-            $prompt = $request->query('prompt', 'consent');
-            if ($prompt == 'none') {
-                if (is_null($user_id)) {
-                    $error = 'login_required';
-                    $error_message = 'The user must log in';
-                } else {
-                    $error = 'interaction_required';
-                    $error_message = 'The user must grant access to your application';
-                }
+        $prompt = $request->query('prompt', 'consent');
+        if ($prompt == 'none') {
+            if (is_null($user_id)) {
+                $error = 'login_required';
+                $error_message = 'The user must log in';
             } else {
-                $error = 'consent_required';
-                $error_message = 'The user denied access to your application';
+                $error = 'interaction_required';
+                $error_message = 'The user must grant access to your application';
             }
-
-            $redirect_uri = $this->redirect_uri ?: $registered_redirect_uri;
-            $response->setRedirect($this->config['redirect_status_code'], $redirect_uri, $this->state, $error, $error_message);
-
-            return;
+        } else {
+            $error = 'consent_required';
+            $error_message = 'The user denied access to your application';
         }
-
-        parent::handleAuthorizeRequest($request, $response, $is_authorized, $user_id);
+        $response->setRedirect($this->config['redirect_status_code'], $redirect_uri, $this->state, $error, $error_message);
     }
 
     protected function buildAuthorizeParameters($request, $response, $user_id)


### PR DESCRIPTION
Relevant links: 
http://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint
http://openid.net/specs/openid-connect-core-1_0.html#AuthError

As you can see, prompt = "consent" matches the previous OAuth2 logic, but the error message has changed (from access_denied to consent_required). We should support that at least.
It should also be possible to support prompt = 'none', which this patch tries to do.

I don't really understand how prompt = 'login' should work (when do we redirect with an error message? Right after the first login fail? That sounds dumb)
Maybe that's why Google doesn't support it either: https://developers.google.com/accounts/docs/OAuth2Login#prompt

Notes: 
- ~~This change causes validateAuthorizeRequest() to be called twice (once by the OpenID method, once by the parent method), which is dumb and wasteful. Need to find a way around that.~~
- ~~Not sure if is_null($user_id) is a good way to check that the user is not logged in. Feels a bit hackish,  so we might want an explicit flag. Why is $user_id even nullable in the first place?~~
- Needs tests.
