### PR TITLE
Add a set check for scope in refresh token grant

### DIFF
--- a/src/OAuth2/GrantType/RefreshToken.php
+++ b/src/OAuth2/GrantType/RefreshToken.php
@@ -78,7 +78,7 @@ class RefreshToken implements GrantTypeInterface
 
     public function getScope()
     {
-        return $this->refreshToken['scope'];
+        return isset($this->refreshToken['scope']) ? $this->refreshToken['scope'] : null;
     }
 
     public function createAccessToken(AccessTokenInterface $accessToken, $client_id, $user_id, $scope)


### PR DESCRIPTION
The refresh token interace suggests that returning a scope is optional,
however the refresh token grant does not handle undefined scopes in the
getScope method correctly the same way other grants, such as the user
credentials grant does.

Modified the getScope method in RefreshToken to return null if the
storage class's getRefreshToken method does not return a scope.

Fixes #422
