### PR TITLE
remove redundant default value from argument

### DIFF
--- a/src/OAuth2/Response.php
+++ b/src/OAuth2/Response.php
@@ -243,7 +243,7 @@ class Response implements ResponseInterface
         }
     }
 
-    public function setRedirect($statusCode = 302, $url, $state = null, $error = null, $errorDescription = null, $errorUri = null)
+    public function setRedirect($statusCode, $url, $state = null, $error = null, $errorDescription = null, $errorUri = null)
     {
         if (empty($url)) {
             throw new \InvalidArgumentException('Cannot redirect to an empty URL.');

--- a/src/OAuth2/ResponseInterface.php
+++ b/src/OAuth2/ResponseInterface.php
@@ -18,7 +18,7 @@ interface ResponseInterface
 
     public function setError($statusCode, $name, $description = null, $uri = null);
 
-    public function setRedirect($statusCode = 302, $url, $state = null, $error = null, $errorDescription = null, $errorUri = null);
+    public function setRedirect($statusCode, $url, $state = null, $error = null, $errorDescription = null, $errorUri = null);
 
     public function getParameter($name);
 }


### PR DESCRIPTION
Incorrect usage of default function arguments.

More info: http://php.net/manual/en/functions.arguments.php Example #5
