### PR TITLE
Fix for token id_token combination as per oauth-v2-multiple-response-types-1_0

### DIFF
--- a/src/OAuth2/OpenID/Controller/AuthorizeController.php
+++ b/src/OAuth2/OpenID/Controller/AuthorizeController.php
@@ -57,8 +57,8 @@ class AuthorizeController extends BaseAuthorizeController implements AuthorizeCo
 
         $nonce = $request->query('nonce');
 
-        // Validate required nonce for "id_token" and "token id_token"
-        if (!$nonce && in_array($this->getResponseType(), array(self::RESPONSE_TYPE_ID_TOKEN, self::RESPONSE_TYPE_TOKEN_ID_TOKEN))) {
+        // Validate required nonce for "id_token", "token id_token" and "id_token token"
+        if (!$nonce && in_array($this->getResponseType(), array(self::RESPONSE_TYPE_ID_TOKEN, self::RESPONSE_TYPE_TOKEN_ID_TOKEN, self::RESPONSE_TYPE_ID_TOKEN_TOKEN))) {
             $response->setError(400, 'invalid_nonce', 'This application requires you specify a nonce parameter');
 
             return false;
@@ -76,6 +76,7 @@ class AuthorizeController extends BaseAuthorizeController implements AuthorizeCo
             self::RESPONSE_TYPE_AUTHORIZATION_CODE,
             self::RESPONSE_TYPE_ID_TOKEN,
             self::RESPONSE_TYPE_TOKEN_ID_TOKEN,
+            self::RESPONSE_TYPE_ID_TOKEN_TOKEN,
         );
     }
 

--- a/src/OAuth2/OpenID/Controller/AuthorizeControllerInterface.php
+++ b/src/OAuth2/OpenID/Controller/AuthorizeControllerInterface.php
@@ -6,4 +6,5 @@ interface AuthorizeControllerInterface
 {
     const RESPONSE_TYPE_ID_TOKEN = 'id_token';
     const RESPONSE_TYPE_TOKEN_ID_TOKEN = 'token id_token';
+    const RESPONSE_TYPE_ID_TOKEN_TOKEN = 'id_token token';
 }

--- a/src/OAuth2/OpenID/ResponseType/IdTokenToken.php
+++ b/src/OAuth2/OpenID/ResponseType/IdTokenToken.php
@@ -4,7 +4,7 @@ namespace OAuth2\OpenID\ResponseType;
 
 use OAuth2\ResponseType\AccessTokenInterface;
 
-class TokenIdToken implements TokenIdTokenInterface
+class IdTokenToken implements IdTokenTokenInterface
 {
     protected $accessToken;
     protected $idToken;

--- a/src/OAuth2/OpenID/ResponseType/IdTokenTokenInterface.php
+++ b/src/OAuth2/OpenID/ResponseType/IdTokenTokenInterface.php
@@ -4,6 +4,6 @@ namespace OAuth2\OpenID\ResponseType;
 
 use OAuth2\ResponseType\ResponseTypeInterface;
 
-interface TokenIdTokenInterface extends ResponseTypeInterface
+interface IdTokenTokenInterface extends ResponseTypeInterface
 {
 }

--- a/src/OAuth2/Server.php
+++ b/src/OAuth2/Server.php
@@ -21,7 +21,7 @@ use OAuth2\ResponseType\AuthorizationCode as AuthorizationCodeResponseType;
 use OAuth2\ResponseType\AccessToken;
 use OAuth2\ResponseType\JwtAccessToken;
 use OAuth2\OpenID\ResponseType\IdToken;
-use OAuth2\OpenID\ResponseType\TokenIdToken;
+use OAuth2\OpenID\ResponseType\IdTokenToken;
 use OAuth2\TokenType\TokenTypeInterface;
 use OAuth2\TokenType\Bearer;
 use OAuth2\GrantType\GrantTypeInterface;
@@ -79,7 +79,8 @@ class Server implements ResourceControllerInterface,
         'token' => 'OAuth2\ResponseType\AccessTokenInterface',
         'code' => 'OAuth2\ResponseType\AuthorizationCodeInterface',
         'id_token' => 'OAuth2\OpenID\ResponseType\IdTokenInterface',
-        'token id_token' => 'OAuth2\OpenID\ResponseType\TokenIdTokenInterface',
+        'token id_token' => 'OAuth2\OpenID\ResponseType\IdTokenTokenInterface',
+        'id_token token' => 'OAuth2\OpenID\ResponseType\IdTokenTokenInterface',
     );
 
     /**
@@ -451,7 +452,8 @@ class Server implements ResourceControllerInterface,
         if ($this->config['use_openid_connect'] && !isset($this->responseTypes['id_token'])) {
             $this->responseTypes['id_token'] = $this->createDefaultIdTokenResponseType();
             if ($this->config['allow_implicit']) {
-                $this->responseTypes['token id_token'] = $this->createDefaultTokenIdTokenResponseType();
+                $this->responseTypes['token id_token'] = $this->createDefaultIdTokenTokenResponseType();
+                $this->responseTypes['id_token token'] = $this->createDefaultIdTokenTokenResponseType();
             }
         }
 
@@ -555,7 +557,8 @@ class Server implements ResourceControllerInterface,
         if ($this->config['use_openid_connect']) {
             $responseTypes['id_token'] = $this->getIdTokenResponseType();
             if ($this->config['allow_implicit']) {
-                $responseTypes['token id_token'] = $this->getTokenIdTokenResponseType();
+                $responseTypes['token id_token'] = $this->getIdTokenTokenResponseType();
+                $responseTypes['id_token token'] = $this->getIdTokenTokenResponseType();
             }
         }
 
@@ -636,13 +639,13 @@ class Server implements ResourceControllerInterface,
         return $this->createDefaultIdTokenResponseType();
     }
 
-    protected function getTokenIdTokenResponseType()
+    protected function getIdTokenTokenResponseType()
     {
-        if (isset($this->responseTypes['token id_token'])) {
-            return $this->responseTypes['token id_token'];
+        if (isset($this->responseTypes['id_token token'])) {
+            return $this->responseTypes['id_token token'];
         }
 
-        return $this->createDefaultTokenIdTokenResponseType();
+        return $this->createDefaultIdTokenTokenResponseType();
     }
 
     /**
@@ -716,9 +719,9 @@ class Server implements ResourceControllerInterface,
         return new IdToken($this->storages['user_claims'], $this->storages['public_key'], $config);
     }
 
-    protected function createDefaultTokenIdTokenResponseType()
+    protected function createDefaultIdTokenTokenResponseType()
     {
-        return new TokenIdToken($this->getAccessTokenResponseType(), $this->getIdTokenResponseType());
+        return new IdTokenToken($this->getAccessTokenResponseType(), $this->getIdTokenResponseType());
     }
 
     public function getResponse()

--- a/test/OAuth2/OpenID/Controller/AuthorizeControllerTest.php
+++ b/test/OAuth2/OpenID/Controller/AuthorizeControllerTest.php
@@ -4,7 +4,7 @@ namespace OAuth2\OpenID\Controller;
 
 use OAuth2\OpenID\Controller\AuthorizeController;
 use OAuth2\OpenID\ResponseType\IdToken;
-use OAuth2\OpenID\ResponseType\TokenIdToken;
+use OAuth2\OpenID\ResponseType\IdTokenToken;
 use OAuth2\ResponseType\AccessToken;
 use OAuth2\Storage\Bootstrap;
 use OAuth2\Server;
@@ -43,6 +43,14 @@ class AuthorizeControllerTest extends \PHPUnit_Framework_TestCase
 
         // Test valid token id_token request
         $request->query['response_type'] = 'token id_token';
+        $this->validateAuthorizeRequest($server, $request, $response);
+
+        // Test valid id_token token request
+        $request->query['response_type'] = 'id_token token';
+        $this->validateAuthorizeRequest($server, $request, $response);
+    }
+
+    private function validateAuthorizeRequest($server, $request, $response){
         $server->handleAuthorizeRequest($request, $response, true);
 
         $parts = parse_url($response->getHttpHeader('Location'));
@@ -72,15 +80,18 @@ class AuthorizeControllerTest extends \PHPUnit_Framework_TestCase
         ));
 
         // Test missing nonce for 'id_token' response type
-        $server->handleAuthorizeRequest($request, $response, true);
+        $this->missingNonce($server, $request, $response);
 
-        $params = $response->getParameters();
-
-        $this->assertEquals($params['error'], 'invalid_nonce');
-        $this->assertEquals($params['error_description'], 'This application requires you specify a nonce parameter');
-
-        // Test missing nonce for 'id_token' response type
+        // Test missing nonce for 'token id_token' response type
         $request->query['response_type'] = 'token id_token';
+        $this->missingNonce($server, $request, $response);
+
+        // Test missing nonce for 'id_token token' response type
+        $request->query['response_type'] = 'id_token token';
+        $this->missingNonce($server, $request, $response);
+    }
+
+    private function missingNonce($server, $request, $response){
         $server->handleAuthorizeRequest($request, $response, true);
 
         $params = $response->getParameters();

--- a/test/OAuth2/OpenID/ResponseType/IdTokenToken.php
+++ b/test/OAuth2/OpenID/ResponseType/IdTokenToken.php
@@ -9,7 +9,7 @@ use OAuth2\Storage\Bootstrap;
 use OAuth2\GrantType\ClientCredentials;
 use OAuth2\ResponseType\AccessToken;
 
-class TokenIdTokenTest extends \PHPUnit_Framework_TestCase
+class IdTokenTokenTest extends \PHPUnit_Framework_TestCase
 {
 
     public function testHandleAuthorizeRequest()
@@ -25,6 +25,21 @@ class TokenIdTokenTest extends \PHPUnit_Framework_TestCase
             'nonce'         => 'test',
         ));
 
+        $this->handleAuthorizeRequest($server, $request);
+
+        $request = new Request(array(
+            'response_type' => 'id_token token',
+            'redirect_uri'  => 'http://adobe.com',
+            'client_id'     => 'Test Client ID',
+            'scope'         => 'openid',
+            'state'         => 'test',
+            'nonce'         => 'test',
+        ));
+
+        $this->handleAuthorizeRequest($server, $request);
+    }
+
+    private function handleAuthorizeRequest($server, $request){
         $server->handleAuthorizeRequest($request, $response = new Response(), true);
 
         $this->assertEquals($response->getStatusCode(), 302);
@@ -83,7 +98,8 @@ class TokenIdTokenTest extends \PHPUnit_Framework_TestCase
             'token' => new AccessToken($memoryStorage, $memoryStorage),
             'id_token' => new IdToken($memoryStorage, $memoryStorage, $config),
         );
-        $responseTypes['token id_token'] = new TokenIdToken($responseTypes['token'], $responseTypes['id_token']);
+        $responseTypes['token id_token'] = new IdTokenToken($responseTypes['token'], $responseTypes['id_token']);
+        $responseTypes['id_token token'] = new IdTokenToken($responseTypes['token'], $responseTypes['id_token']);
 
         $server = new Server($memoryStorage, $config, array(), $responseTypes);
         $server->addGrantType(new ClientCredentials($memoryStorage));

--- a/test/OAuth2/ServerTest.php
+++ b/test/OAuth2/ServerTest.php
@@ -527,6 +527,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('OAuth2\OpenID\ResponseType\IdTokenInterface', $server->getResponseType('id_token'));
         $this->assertNull($server->getResponseType('token id_token'));
+        $this->assertNull($server->getResponseType('id_token token'));
     }
 
     /**
@@ -561,7 +562,8 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $server->getAuthorizeController();
 
         $this->assertInstanceOf('OAuth2\OpenID\ResponseType\IdTokenInterface', $server->getResponseType('id_token'));
-        $this->assertInstanceOf('OAuth2\OpenID\ResponseType\TokenIdTokenInterface', $server->getResponseType('token id_token'));
+        $this->assertInstanceOf('OAuth2\OpenID\ResponseType\IdTokenTokenInterface', $server->getResponseType('token id_token'));
+        $this->assertInstanceOf('OAuth2\OpenID\ResponseType\IdTokenTokenInterface', $server->getResponseType('id_token token'));
     }
 
     public function testUsingOpenIDConnectWithAllowImplicitAndAccessTokenStorageIsOkay()
@@ -579,7 +581,8 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $server->getAuthorizeController();
 
         $this->assertInstanceOf('OAuth2\OpenID\ResponseType\IdTokenInterface', $server->getResponseType('id_token'));
-        $this->assertInstanceOf('OAuth2\OpenID\ResponseType\TokenIdTokenInterface', $server->getResponseType('token id_token'));
+        $this->assertInstanceOf('OAuth2\OpenID\ResponseType\IdTokenTokenInterface', $server->getResponseType('token id_token'));
+        $this->assertInstanceOf('OAuth2\OpenID\ResponseType\IdTokenTokenInterface', $server->getResponseType('id_token token'));
     }
 
     public function testUsingOpenIDConnectWithAllowImplicitAndAccessTokenResponseTypeIsOkay()
@@ -600,7 +603,8 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $server->getAuthorizeController();
 
         $this->assertInstanceOf('OAuth2\OpenID\ResponseType\IdTokenInterface', $server->getResponseType('id_token'));
-        $this->assertInstanceOf('OAuth2\OpenID\ResponseType\TokenIdTokenInterface', $server->getResponseType('token id_token'));
+        $this->assertInstanceOf('OAuth2\OpenID\ResponseType\IdTokenTokenInterface', $server->getResponseType('token id_token'));
+        $this->assertInstanceOf('OAuth2\OpenID\ResponseType\IdTokenTokenInterface', $server->getResponseType('id_token token'));
     }
 
     /**


### PR DESCRIPTION
Section 5 from http://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#Combinations lists the valid combination as id_token token.  After this change both the sample request from the same section and the sample request from http://openid.net/specs/openid-connect-core-1_0.html#id_token-tokenExample are treated as valid.
