### PR TITLE
Changed the constructor to expect MongoClient instead of legacy MongoDB

### DIFF
--- a/src/OAuth2/Storage/Mongo.php
+++ b/src/OAuth2/Storage/Mongo.php
@@ -29,7 +29,7 @@ class Mongo implements AuthorizationCodeInterface,
 
     public function __construct($connection, $config = array())
     {
-        if ($connection instanceof \MongoDB) {
+        if ($connection instanceof \MongoClient) {
             $this->db = $connection;
         } else {
             if (!is_array($connection)) {


### PR DESCRIPTION
The documentation says to use the MongoClient class but without this change it was throwing an error as the constructor was expecting the legacy MongoDB object as parameter: First argument to OAuth2\Storage\Mongo must be an instance of MongoDB or a configuration array.
