### PR TITLE
Rename JWT claims for JWT Access Tokens: #338

### DIFF
--- a/src/OAuth2/ResponseType/JwtAccessToken.php
+++ b/src/OAuth2/ResponseType/JwtAccessToken.php
@@ -29,6 +29,7 @@ class JwtAccessToken extends AccessToken
         $this->publicKeyStorage = $publicKeyStorage;
         $config = array_merge(array(
             'store_encrypted_token_string' => true,
+            'issuer' => ''
         ), $config);
         if (is_null($tokenStorage)) {
             // a pass-thru, so we can call the parent constructor
@@ -62,9 +63,11 @@ class JwtAccessToken extends AccessToken
         $expires = time() + $this->config['access_lifetime'];
         $jwtAccessToken = array(
             'id'         => $this->generateAccessToken(),
-            'client_id'  => $client_id,
-            'user_id'    => $user_id,
-            'expires'    => $expires,
+            'iss'        => $this->config['issuer'],
+            'aud'        => $client_id,
+            'sub'        => $user_id,
+            'exp'        => $expires,
+            'iat'        => time(),
             'token_type' => $this->config['token_type'],
             'scope'      => $scope
         );

--- a/src/OAuth2/Storage/JwtAccessToken.php
+++ b/src/OAuth2/Storage/JwtAccessToken.php
@@ -39,7 +39,7 @@ class JwtAccessToken implements JwtAccessTokenInterface
             return false;
         }
 
-        $client_id  = isset($tokenData['client_id']) ? $tokenData['client_id'] : null;
+        $client_id  = isset($tokenData['aud']) ? $tokenData['aud'] : null;
         $public_key = $this->publicKeyStorage->getPublicKey($client_id);
         $algorithm  = $this->publicKeyStorage->getEncryptionAlgorithm($client_id);
 
@@ -48,7 +48,8 @@ class JwtAccessToken implements JwtAccessTokenInterface
             return false;
         }
 
-        return $tokenData;
+        // normalize the JWT claims to the format expected by other components in this library
+        return $this->convertJwtToOAuth2($tokenData);
     }
 
     public function setAccessToken($oauth_token, $client_id, $user_id, $expires, $scope = null)
@@ -56,5 +57,24 @@ class JwtAccessToken implements JwtAccessTokenInterface
         if ($this->tokenStorage) {
             return $this->tokenStorage->setAccessToken($oauth_token, $client_id, $user_id, $expires, $scope);
         }
+    }
+
+    // converts a JWT access token into an OAuth2-friendly format
+    protected function convertJwtToOAuth2($tokenData)
+    {
+        $keyMapping = array(
+            'aud' => 'client_id',
+            'exp' => 'expires',
+            'sub' => 'user_id'
+        );
+
+        foreach ($keyMapping as $jwtKey => $oauth2Key) {
+            if (isset($tokenData[$jwtKey])) {
+                $tokenData[$oauth2Key] = $tokenData[$jwtKey];
+                unset($tokenData[$jwtKey]);                
+            }
+        }
+
+        return $tokenData;
     }
 }


### PR DESCRIPTION
Hey all,

Thank you for creating such a fantastic library. It has been very useful to me. This pull request is my attempt to finish addressing #338 for JWT Access Tokens. A couple of notes here:
- renamed `client_id` to `aud`
- renamed `expires` to `exp`
- renamed `user_id` to `sub`
- added the `iss` parameter from an optional `issuer` configuration value
- added the `iat` parameter for the time the JWT access token was issued

I also added a method that maps the decoded access token from the JWT claims format to the format expected by other parts of this library. Hope this is helpful!
- Jared
