### PR TITLE
Make validateAuthorizeRequest not specific to a single HTTP method.

### DIFF
--- a/src/OAuth2/Controller/AuthorizeController.php
+++ b/src/OAuth2/Controller/AuthorizeController.php
@@ -129,7 +129,7 @@ class AuthorizeController implements AuthorizeControllerInterface
     public function validateAuthorizeRequest(RequestInterface $request, ResponseInterface $response)
     {
         // Make sure a valid client id was supplied (we can not redirect because we were unable to verify the URI)
-        if (!$client_id = $request->query("client_id")) {
+        if (!$client_id = $request->get("client_id")) {
             // We don't have a good URI to use
             $response->setError(400, 'invalid_client', "No client id supplied");
 
@@ -149,7 +149,7 @@ class AuthorizeController implements AuthorizeControllerInterface
         // @see http://tools.ietf.org/html/rfc6749#section-3.1.2
         // @see http://tools.ietf.org/html/rfc6749#section-4.1.2.1
         // @see http://tools.ietf.org/html/rfc6749#section-4.2.2.1
-        if ($supplied_redirect_uri = $request->query('redirect_uri')) {
+        if ($supplied_redirect_uri = $request->get('redirect_uri')) {
             // validate there is no fragment supplied
             $parts = parse_url($supplied_redirect_uri);
             if (isset($parts['fragment']) && $parts['fragment']) {
@@ -182,8 +182,8 @@ class AuthorizeController implements AuthorizeControllerInterface
         }
 
         // Select the redirect URI
-        $response_type = $request->query('response_type');
-        $state = $request->query('state');
+        $response_type = $request->get('response_type');
+        $state = $request->get('state');
 
         // type and client_id are required
         if (!$response_type || !in_array($response_type, $this->getValidResponseTypes())) {

--- a/src/OAuth2/Request.php
+++ b/src/OAuth2/Request.php
@@ -92,6 +92,25 @@ class Request implements RequestInterface
     }
 
     /**
+     * Gets a "parameter" value.
+     *
+     * Order of precedence: GET, POST
+     *
+     * @param string  $name    the name of the parameter
+     * @param mixed   $default the default value
+     *
+     * @return mixed
+     */
+    public function get($name, $default = null)
+    {
+        if (isset($this->query[$name])) {
+            return $this->query[$name];
+        }
+
+        return $this->request($name, $default);
+    }
+
+    /**
      * Returns the request body content.
      *
      * @param Boolean $asResource If true, a resource will be returned

--- a/test/OAuth2/RequestTest.php
+++ b/test/OAuth2/RequestTest.php
@@ -75,6 +75,35 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Basic secret', $request->headers('Authorization'));
     }
 
+    public function testGetReturnsGetParamIfAvailable()
+    {
+        $query   = array('client_id' => 'correct');
+        $request = array('client_id' => 'incorrect');
+
+        $request = new Request($query, $request);
+
+        $this->assertEquals('correct', $request->get('client_id'));
+    }
+
+    public function testGetReturnsPostParamIfGetParamNotAvailable()
+    {
+        $request = array('client_id' => 'correct');
+
+        $request = new Request(
+            array(),
+            $request
+        );
+
+        $this->assertEquals('correct', $request->get('client_id'));
+    }
+
+    public function testGetReturnsDefaultIfNoGetOrPostParamAvailable()
+    {
+        $request = new Request();
+
+        $this->assertEquals('correct', $request->get('client_id', 'correct'));
+    }
+
     private function getTestServer($config = array())
     {
         $storage = Bootstrap::getInstance()->getMemoryStorage();


### PR DESCRIPTION
This pull request changes `AuthorizeController::validateAuthorizeRequest` to retrieve parameters from either the GET or POST params. (Currently it expects them as GET params.)

A `GET` form will send usernames and passwords in the URL, which could be cached in the user's browser history. This makes `POST` more secure. The spec doesn't enforce one method over the other.
