### PR TITLE
only get bearer header from http headers and ignore basic authorization ...

### DIFF
--- a/src/OAuth2/ClientAssertionType/HttpBasic.php
+++ b/src/OAuth2/ClientAssertionType/HttpBasic.php
@@ -34,6 +34,7 @@ class HttpBasic implements ClientAssertionTypeInterface
         $this->config = array_merge(array(
             'allow_credentials_in_request_body' => true,
             'allow_public_clients' => true,
+            'token_bearer_header_name' => 'Bearer',
         ), $config);
     }
 
@@ -97,7 +98,7 @@ class HttpBasic implements ClientAssertionTypeInterface
      */
     public function getClientCredentials(RequestInterface $request, ResponseInterface $response = null)
     {
-        if (!is_null($request->headers('PHP_AUTH_USER')) && !is_null($request->headers('PHP_AUTH_PW'))) {
+        if (preg_match('/' . $this->config['token_bearer_header_name'] . '\s(\S+)/', $request->headers('AUTHORIZATION')) && !is_null($request->headers('PHP_AUTH_USER')) && !is_null($request->headers('PHP_AUTH_PW'))) {
             return array('client_id' => $request->headers('PHP_AUTH_USER'), 'client_secret' => $request->headers('PHP_AUTH_PW'));
         }
 


### PR DESCRIPTION
Can anyone please review it see if it makes any sense? Thanks. 

It's quite common that http basic auth is enabled on web server during development. 
e.g. developers are working on integrating oauth2 into their web app on their staging while the staging has http basic auth enabled. 

In that case, the normal http basic auth header conflicts with the oauth2 bearer header. 
