### PR TITLE
Update AccessToken.php

### DIFF
--- a/src/OAuth2/ResponseType/AccessToken.php
+++ b/src/OAuth2/ResponseType/AccessToken.php
@@ -114,18 +114,27 @@ class AccessToken implements AccessTokenInterface
      */
     protected function generateAccessToken()
     {
-        $tokenLen = 40;
         if (function_exists('mcrypt_create_iv')) {
-            $randomData = mcrypt_create_iv(100, MCRYPT_DEV_URANDOM);
-        } elseif (function_exists('openssl_random_pseudo_bytes')) {
-            $randomData = openssl_random_pseudo_bytes(100);
-        } elseif (@file_exists('/dev/urandom')) { // Get 100 bytes of random data
-            $randomData = file_get_contents('/dev/urandom', false, null, 0, 100) . uniqid(mt_rand(), true);
-        } else {
-            $randomData = mt_rand() . mt_rand() . mt_rand() . mt_rand() . microtime(true) . uniqid(mt_rand(), true);
+            $randomData = mcrypt_create_iv(20, MCRYPT_DEV_URANDOM);
+            if ($randomData !== false && strlen($randomData) === 20) {
+                return bin2hex($randomData);
+            }
         }
-
-        return substr(hash('sha512', $randomData), 0, $tokenLen);
+        if (function_exists('openssl_random_pseudo_bytes')) {
+            $randomData = openssl_random_pseudo_bytes(20);
+            if ($randomData !== false && strlen($randomData) === 20) {
+                return bin2hex($randomData);
+            }
+        } 
+        if (@file_exists('/dev/urandom')) { // Get 100 bytes of random data
+            $randomData = file_get_contents('/dev/urandom', false, null, 0, 20);
+            if ($randomData !== false && strlen($randomData) === 20) {
+                return bin2hex($randomData);
+            }
+        }
+        // Last resort which you probably should just get rid of:
+        $randomData = mt_rand() . mt_rand() . mt_rand() . mt_rand() . microtime(true) . uniqid(mt_rand(), true);
+        return substr(hash('sha512', $randomData), 0, 40);
     }
 
     /**


### PR DESCRIPTION
When a CSPRNG is available, just grab as many bytes as necessary and return `bin2hex($randomData)'. When there isn't, use the legacy hashing mode. Though PHP >= 5.3.0 will always have`openssl_random_pseudo_bytes()` available.
