### PR TITLE
Allow any whitespace as a redirect URI delimiter

### DIFF
--- a/src/OAuth2/Controller/AuthorizeController.php
+++ b/src/OAuth2/Controller/AuthorizeController.php
@@ -324,7 +324,7 @@ class AuthorizeController implements AuthorizeControllerInterface
             return false; // if either one is missing, assume INVALID
         }
 
-        $registered_uris = explode(' ', $registeredUriString);
+        $registered_uris = preg_split('/\s+/', $registeredUriString);
         foreach ($registered_uris as $registered_uri) {
             if ($this->config['require_exact_redirect_uri']) {
                 // the input uri is validated against the registered uri using exact match


### PR DESCRIPTION
None of them are valid URI components, and line-breaks make them easier to maintain.
