### PR TITLE
Removed set of mongo.native_long from Mongo.php

### DIFF
--- a/src/OAuth2/Storage/Mongo.php
+++ b/src/OAuth2/Storage/Mongo.php
@@ -40,9 +40,6 @@ class Mongo implements AuthorizationCodeInterface,
             $this->db = $m->{$connection['database']};
         }
 
-        // Unix timestamps might get larger than 32 bits,
-        // so let's add native support for 64 bit ints.
-        ini_set('mongo.native_long', 1);
 
         $this->config = array_merge(array(
             'client_table' => 'oauth_clients',


### PR DESCRIPTION
Removed 
```
ini_set('mongo.native_long', 1) 
```
as it's not supported on 32 bit machine. Also that value is set to 1 by default.

https://github.com/mongodb/mongo-php-driver/commit/374d8048d3d512057ade23a7538d5f4bb2a7fdd1

With that instruction, the project run fails with error:
> Fatal error: ini_set(): To prevent data corruption, you are not allowed to turn on the mongo.native_long setting on 32-bit platforms in Unknown on line 0