### PR TITLE
Adding -H "Authorization:Basic " possibility

### DIFF
--- a/src/OAuth2/ClientAssertionType/HttpBasic.php
+++ b/src/OAuth2/ClientAssertionType/HttpBasic.php
@@ -101,6 +101,16 @@ class HttpBasic implements ClientAssertionTypeInterface
             return array('client_id' => $request->headers('PHP_AUTH_USER'), 'client_secret' => $request->headers('PHP_AUTH_PW'));
         }
 
+        if (!is_null($request->headers('Authorization'))) {
+          $auth = $request->headers('Authorization');
+          if (preg_match('/^Basic\s/', $auth)) {
+            $authBase = base64_decode(preg_replace('/^Basic\s/', '', $auth));
+            $data = explode(',', $authBase);
+
+            return array('client_id' => $data[0], 'client_secret' => $data[1]);
+          }
+        }
+
         if ($this->config['allow_credentials_in_request_body']) {
             // Using POST for HttpBasic authorization is not recommended, but is supported by specification
             if (!is_null($request->request('client_id'))) {

--- a/src/OAuth2/ClientAssertionType/HttpBasic.php
+++ b/src/OAuth2/ClientAssertionType/HttpBasic.php
@@ -107,7 +107,9 @@ class HttpBasic implements ClientAssertionTypeInterface
             $authBase = base64_decode(preg_replace('/^Basic\s/', '', $auth));
             $data = explode(',', $authBase);
 
-            return array('client_id' => $data[0], 'client_secret' => $data[1]);
+            if (!empty($data[0]) && !empty($data[1])) {
+              return array('client_id' => $data[0], 'client_secret' => $data[1]);
+            }
           }
         }
 

--- a/src/OAuth2/ClientAssertionType/HttpBasic.php
+++ b/src/OAuth2/ClientAssertionType/HttpBasic.php
@@ -105,7 +105,7 @@ class HttpBasic implements ClientAssertionTypeInterface
           $auth = $request->headers('Authorization');
           if (preg_match('/^Basic\s/', $auth)) {
             $authBase = base64_decode(preg_replace('/^Basic\s/', '', $auth));
-            $data = explode(',', $authBase);
+            $data = explode(':', $authBase);
 
             if (!empty($data[0]) && !empty($data[1])) {
               return array('client_id' => $data[0], 'client_secret' => $data[1]);


### PR DESCRIPTION
Just added the possibility to use the standard Basic Authorization header.

```PHP
base64_encode('ClientId,ClientSecret);
```

**Example Request**
```
curl -H "Authorization:Basic VGVzdENsaWVudCxUZXN0U2VjcmV0" https://api.mysite.com/token -d 'grant_type=client_credentials'
{"access_token":"03807cb390319329bdf6c777d4dfae9c0d3b3c35","expires_in":3600,"token_type":"Bearer","scope":null}
```