### PR TITLE
Fix #505 dynamodb value must not be empty

### DIFF
--- a/src/OAuth2/Storage/DynamoDB.php
+++ b/src/OAuth2/Storage/DynamoDB.php
@@ -171,7 +171,7 @@ class DynamoDB implements
         $expires = date('Y-m-d H:i:s', $expires);
 
         $clientData = compact('access_token', 'client_id', 'user_id', 'expires', 'scope');
-        $clientData = array_filter($clientData, function ($value) { return !is_null($value); });
+        $clientData = array_filter($clientData, function ($value) { return !empty($value); });
 
         $result = $this->client->putItem(array(
             'TableName' =>  $this->config['access_token_table'],
@@ -208,7 +208,7 @@ class DynamoDB implements
         $expires = date('Y-m-d H:i:s', $expires);
 
         $clientData = compact('authorization_code', 'client_id', 'user_id', 'redirect_uri', 'expires', 'id_token', 'scope');
-        $clientData = array_filter($clientData, function ($value) { return !is_null($value); });
+        $clientData = array_filter($clientData, function ($value) { return !empty($value); });
 
         $result = $this->client->putItem(array(
             'TableName' =>  $this->config['code_table'],
@@ -309,7 +309,7 @@ class DynamoDB implements
         $expires = date('Y-m-d H:i:s', $expires);
 
         $clientData = compact('refresh_token', 'client_id', 'user_id', 'expires', 'scope');
-        $clientData = array_filter($clientData, function ($value) { return !is_null($value); });
+        $clientData = array_filter($clientData, function ($value) { return !empty($value); });
 
         $result = $this->client->putItem(array(
             'TableName' =>  $this->config['refresh_token_table'],
@@ -411,7 +411,7 @@ class DynamoDB implements
                 $defaultScope[]  = $item['scope']['S'];
             }
 
-            return implode(' ', $defaultScope);
+            return empty($defaultScope) ? null : implode(' ', $defaultScope);
         }
 
         return null;

--- a/test/OAuth2/Storage/AccessTokenTest.php
+++ b/test/OAuth2/Storage/AccessTokenTest.php
@@ -48,5 +48,10 @@ class AccessTokenTest extends BaseTest
         $this->assertEquals($token['client_id'], 'client ID2');
         $this->assertEquals($token['user_id'], 'SOMEOTHERID');
         $this->assertEquals($token['expires'], $expires);
+
+        // add token with scope having an empty string value
+        $expires = time() + 42;
+        $success = $storage->setAccessToken('newtoken', 'client ID', 'SOMEOTHERID', $expires, '');
+        $this->assertTrue($success);
     }
 }

--- a/test/OAuth2/Storage/AuthorizationCodeTest.php
+++ b/test/OAuth2/Storage/AuthorizationCodeTest.php
@@ -70,6 +70,11 @@ class AuthorizationCodeTest extends BaseTest
         $this->assertEquals($code['user_id'], 'SOMEOTHERID');
         $this->assertEquals($code['redirect_uri'], 'http://example.org');
         $this->assertEquals($code['expires'], $expires);
+
+        // add new code with scope having an empty string value
+        $expires = time() + 20;
+        $success = $storage->setAuthorizationCode('newcode', 'client ID', 'SOMEUSERID', 'http://example.com', $expires, '');
+        $this->assertTrue($success);
     }
 
         /** @dataProvider provideStorage */

--- a/test/OAuth2/Storage/DynamoDBTest.php
+++ b/test/OAuth2/Storage/DynamoDBTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace OAuth2\Storage;
+
+class DynamoDBTest extends BaseTest
+{
+    public function testGetDefaultScope()
+    {
+        $client = $this->getMockBuilder('\Aws\DynamoDb\DynamoDbClient')
+            ->disableOriginalConstructor()
+            ->setMethods(array('query'))
+            ->getMock();
+
+        $return = $this->getMockBuilder('\Guzzle\Service\Resource\Model')
+            ->setMethods(array('count', 'toArray'))
+            ->getMock();
+
+        $data = array(
+            'Items' => array(),
+            'Count' => 0,
+            'ScannedCount'=> 0
+        );
+
+        $return->expects($this->once())
+            ->method('count')
+            ->will($this->returnValue(count($data)));
+
+        $return->expects($this->once())
+            ->method('toArray')
+            ->will($this->returnValue($data));
+
+
+        // should return null default scope if none is set in database
+        $client->expects($this->once())
+            ->method('query')
+            ->will($this->returnValue($return));
+
+        $storage = new DynamoDB($client);
+        $this->assertNull($storage->getDefaultScope());
+    }
+}

--- a/test/OAuth2/Storage/RefreshTokenTest.php
+++ b/test/OAuth2/Storage/RefreshTokenTest.php
@@ -32,5 +32,10 @@ class RefreshTokenTest extends BaseTest
         $this->assertEquals($token['client_id'], 'client ID');
         $this->assertEquals($token['user_id'], 'SOMEUSERID');
         $this->assertEquals($token['expires'], $expires);
+
+        // add token with scope having an empty string value
+        $expires = time() + 20;
+        $success = $storage->setRefreshToken('refreshtoken2', 'client ID', 'SOMEUSERID', $expires, '');
+        $this->assertTrue($success);
     }
 }


### PR DESCRIPTION
Changed filtering of client data by using empty() instead of is_null() in the setAccessToken, setAuthorizationCode and setRefreshToken methods of the DynamoDB storage..
Changed the getDefaultScope method to return null if there is no default scope set in the database.
Added tests for these changes. 