### PR TITLE
[php5.2] Make validateRedirectUri protected to be able to override

### DIFF
--- a/src/OAuth2/Controller/AuthorizeController.php
+++ b/src/OAuth2/Controller/AuthorizeController.php
@@ -227,7 +227,7 @@ class OAuth2_Controller_AuthorizeController implements OAuth2_Controller_Authori
      *
      * @see http://tools.ietf.org/html/rfc6749#section-3.1.2
      */
-    private function validateRedirectUri($inputUri, $registeredUriString)
+    protected function validateRedirectUri($inputUri, $registeredUriString)
     {
         if (!$inputUri || !$registeredUriString) {
             return false; // if either one is missing, assume INVALID


### PR DESCRIPTION
Like #512 for develop branch.

This change is aginst php5.2-develop. I'm not sure if this branch is still active, nevertheless I have to use it on our SLES 10 Server with Php 5.2.