### PR TITLE
checkScope should take complete token, not just scope

### DIFF
--- a/src/OAuth2/Controller/AuthorizeController.php
+++ b/src/OAuth2/Controller/AuthorizeController.php
@@ -237,7 +237,7 @@ class AuthorizeController implements AuthorizeControllerInterface
             // otherwise verify the scope exists
             $clientScope = $this->clientStorage->getClientScope($client_id);
             if ((is_null($clientScope) && !$this->scopeUtil->scopeExists($requestedScope))
-                || ($clientScope && !$this->scopeUtil->checkScope($requestedScope, $clientScope))) {
+                || ($clientScope && !$this->scopeUtil->checkScope($requestedScope, array('scope' => $clientScope)))) {
                 $response->setRedirect($this->config['redirect_status_code'], $redirect_uri, $state, 'invalid_scope', 'An unsupported scope was requested', null);
 
                 return false;

--- a/src/OAuth2/Controller/ResourceController.php
+++ b/src/OAuth2/Controller/ResourceController.php
@@ -50,7 +50,7 @@ class ResourceController implements ResourceControllerInterface
          * If token doesn't have a scope, it's null/empty, or it's insufficient, then throw 403
          * @see http://tools.ietf.org/html/rfc6750#section-3.1
          */
-        if ($scope && (!isset($token["scope"]) || !$token["scope"] || !$this->scopeUtil->checkScope($scope, $token["scope"]))) {
+        if ($scope && (!isset($token["scope"]) || !$token["scope"] || !$this->scopeUtil->checkScope($scope, $token))) {
             $response->setError(403, 'insufficient_scope', 'The request requires higher privileges than provided by the access token');
             $response->addHttpHeaders(array(
                 'WWW-Authenticate' => sprintf('%s realm="%s", scope="%s", error="%s", error_description="%s"',

--- a/src/OAuth2/Controller/TokenController.php
+++ b/src/OAuth2/Controller/TokenController.php
@@ -162,7 +162,7 @@ class TokenController implements TokenControllerInterface
         if ($requestedScope) {
             // validate the requested scope
             if ($availableScope) {
-                if (!$this->scopeUtil->checkScope($requestedScope, $availableScope)) {
+                if (!$this->scopeUtil->checkScope($requestedScope, $grantType)) {
                     $response->setError(400, 'invalid_scope', 'The scope requested is invalid for this request');
 
                     return null;
@@ -170,7 +170,7 @@ class TokenController implements TokenControllerInterface
             } else {
                 // validate the client has access to this scope
                 if ($clientScope = $this->clientStorage->getClientScope($clientId)) {
-                    if (!$this->scopeUtil->checkScope($requestedScope, $clientScope)) {
+                    if (!$this->scopeUtil->checkScope($requestedScope, array('scope' => $clientScope))) {
                         $response->setError(400, 'invalid_scope', 'The scope requested is invalid for this client');
 
                         return false;

--- a/src/OAuth2/OpenID/Controller/AuthorizeController.php
+++ b/src/OAuth2/OpenID/Controller/AuthorizeController.php
@@ -95,7 +95,7 @@ class AuthorizeController extends BaseAuthorizeController implements AuthorizeCo
     public function needsIdToken($request_scope)
     {
         // see if the "openid" scope exists in the requested scope
-        return $this->scopeUtil->checkScope('openid', $request_scope);
+        return $this->scopeUtil->checkScope('openid', array('scope' => $request_scope));
     }
 
     public function getNonce()

--- a/src/OAuth2/Scope.php
+++ b/src/OAuth2/Scope.php
@@ -4,6 +4,7 @@ namespace OAuth2;
 
 use OAuth2\Storage\Memory;
 use OAuth2\Storage\ScopeInterface as ScopeStorageInterface;
+use OAuth2\GrantType\GrantTypeInterface;
 
 /**
 * @see OAuth2\ScopeInterface
@@ -43,12 +44,22 @@ class Scope implements ScopeInterface
      *
      * @ingroup oauth2_section_7
      */
-    public function checkScope($required_scope, $available_scope)
+    public function checkScope($required_scope, $grant_type)
     {
+        $available_scope = $this->getScopeFromGrantType($grant_type);
         $required_scope = explode(' ', trim($required_scope));
         $available_scope = explode(' ', trim($available_scope));
 
         return (count(array_diff($required_scope, $available_scope)) == 0);
+    }
+
+    private function getScopeFromGrantType($grant_type)
+    {
+        if ($grant_type instanceof GrantTypeInterface) {
+            return $grant_type->getScope();
+        }
+
+        return $grant_type["scope"];
     }
 
     /**

--- a/src/OAuth2/ScopeInterface.php
+++ b/src/OAuth2/ScopeInterface.php
@@ -25,7 +25,7 @@ interface ScopeInterface extends ScopeStorageInterface
      *
      * @ingroup oauth2_section_7
      */
-    public function checkScope($required_scope, $available_scope);
+    public function checkScope($required_scope, $grantType);
 
     /**
      * Return scope info from request

--- a/test/OAuth2/ScopeTest.php
+++ b/test/OAuth2/ScopeTest.php
@@ -10,12 +10,12 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
     {
         $scopeUtil = new Scope();
 
-        $this->assertFalse($scopeUtil->checkScope('invalid', 'list of scopes'));
-        $this->assertTrue($scopeUtil->checkScope('valid', 'valid and-some other-scopes'));
-        $this->assertTrue($scopeUtil->checkScope('valid another-valid', 'valid another-valid and-some other-scopes'));
+        $this->assertFalse($scopeUtil->checkScope('invalid', array('scope' => 'list of scopes')));
+        $this->assertTrue($scopeUtil->checkScope('valid', array('scope' => 'valid and-some other-scopes')));
+        $this->assertTrue($scopeUtil->checkScope('valid another-valid', array('scope' => 'valid another-valid and-some other-scopes')));
         // all scopes must match
-        $this->assertFalse($scopeUtil->checkScope('valid invalid', 'valid and-some other-scopes'));
-        $this->assertFalse($scopeUtil->checkScope('valid valid2 invalid', 'valid valid2 and-some other-scopes'));
+        $this->assertFalse($scopeUtil->checkScope('valid invalid', array('scope' => 'valid and-some other-scopes')));
+        $this->assertFalse($scopeUtil->checkScope('valid valid2 invalid', array('scope' => 'valid valid2 and-some other-scopes')));
     }
 
     public function testScopeStorage()


### PR DESCRIPTION
Hi,

I need to add an 'admin' functionality to my existing API, which should work simply - admin is able to do everything, no matter if user allowed required scope or not.

This can be implemented either in `ResourceController` or in `Scope`. The `Scope` place fits better, because the rights is related to scope. But currently it's not possible to implement, because there's no way how to check if user is admin in `ScopeInterface::checkScope` method.

The following interface makes it possible:

```
ScopeInterface::checkScope(string $required_scope, $grantType);
```