### PR TITLE
Sign tokens with client_secret instead of private key for MAC-based algorithms

### DIFF
--- a/src/OAuth2/Server.php
+++ b/src/OAuth2/Server.php
@@ -718,7 +718,7 @@ class Server implements ResourceControllerInterface,
 
         $config = array_intersect_key($this->config, array_flip(explode(' ', 'issuer id_lifetime')));
 
-        return new IdToken($this->storages['user_claims'], $this->storages['public_key'], $config);
+        return new IdToken($this->storages['user_claims'], $this->storages['public_key'], $this->storages['client_credentials'], $config);
     }
 
     protected function createDefaultIdTokenTokenResponseType()


### PR DESCRIPTION
Adjusting for OpenID Connect id_token when using HS256, HS384, or HS512: http://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation [3.1.3.7.8]