### PR TITLE
Makes possible to inherit from Oauth2\Request and use own Request class instead of original

### DIFF
--- a/src/OAuth2/Request.php
+++ b/src/OAuth2/Request.php
@@ -191,7 +191,7 @@ class Request implements RequestInterface
      */
     public static function createFromGlobals()
     {
-        $class = __CLASS__;
+        $class = get_called_class();
         $request = new $class($_GET, $_POST, array(), $_COOKIE, $_FILES, $_SERVER);
 
         $contentType = $request->server('CONTENT_TYPE', '');


### PR DESCRIPTION
Makes possible to use own featured Request like this:

```php  
MyRequest extends \OAuth2\Request {
    public function someCoolFeature ($arg) {
        return $it;
    }
};

$request = MyRequest::createFromGlobals();

$server->handleTokenRequest($request);
```