### PR TITLE
fix: priority of client grant type validation in TokenController

### DIFF
--- a/src/OAuth2/Controller/TokenController.php
+++ b/src/OAuth2/Controller/TokenController.php
@@ -113,8 +113,17 @@ class TokenController implements TokenControllerInterface
                 return null;
             }
             $clientId = $this->clientAssertionType->getClientId();
+
+            // validate the Client ID (if applicable)
+            if (!is_null($storedClientId = $grantType->getClientId()) && $storedClientId != $clientId) {
+                $response->setError(400, 'invalid_grant', sprintf('%s doesn\'t exist or is invalid for the client', $grantTypeIdentifier));
+
+                return null;
+            }
+        } else {
+            $clientId = $grantType->getClientId();
         }
-        
+
         /**
          * Validate the client can use the requested grant type
          */
@@ -132,17 +141,6 @@ class TokenController implements TokenControllerInterface
          */
         if (!$grantType->validateRequest($request, $response)) {
             return null;
-        }
-
-        if ($grantType instanceof ClientAssertionTypeInterface) {
-            $clientId = $grantType->getClientId();
-        } else {
-            // validate the Client ID (if applicable)
-            if (!is_null($storedClientId = $grantType->getClientId()) && $storedClientId != $clientId) {
-                $response->setError(400, 'invalid_grant', sprintf('%s doesn\'t exist or is invalid for the client', $grantTypeIdentifier));
-
-                return null;
-            }
         }
 
         /**

--- a/src/OAuth2/Controller/TokenController.php
+++ b/src/OAuth2/Controller/TokenController.php
@@ -114,6 +114,15 @@ class TokenController implements TokenControllerInterface
             }
             $clientId = $this->clientAssertionType->getClientId();
         }
+        
+        /**
+         * Validate the client can use the requested grant type
+         */
+        if (!$this->clientStorage->checkRestrictedGrantType($clientId, $grantTypeIdentifier)) {
+            $response->setError(400, 'unauthorized_client', 'The grant type is unauthorized for this client_id');
+
+            return false;
+        }
 
         /**
          * Retrieve the grant type information from the request
@@ -134,15 +143,6 @@ class TokenController implements TokenControllerInterface
 
                 return null;
             }
-        }
-
-        /**
-         * Validate the client can use the requested grant type
-         */
-        if (!$this->clientStorage->checkRestrictedGrantType($clientId, $grantTypeIdentifier)) {
-            $response->setError(400, 'unauthorized_client', 'The grant type is unauthorized for this client_id');
-
-            return false;
         }
 
         /**


### PR DESCRIPTION
If the grant type is not available for the selected client, throw an exception before checking if the requested grant type (credentials, etc) is valid.
It can avoid requesting resources for nothing.