### PR TITLE
fix resource request without access_token

### DIFF
--- a/src/OAuth2/Controller/ResourceController.php
+++ b/src/OAuth2/Controller/ResourceController.php
@@ -74,19 +74,19 @@ class ResourceController implements ResourceControllerInterface
     public function getAccessTokenData(RequestInterface $request, ResponseInterface $response)
     {
         // Get the token parameter
-        if ($token_param = $this->tokenType->getAccessTokenParameter($request, $response)) {
-            // Get the stored token data (from the implementing subclass)
-            // Check we have a well formed token
-            // Check token expiration (expires is a mandatory paramter)
-            if (!$token = $this->tokenStorage->getAccessToken($token_param)) {
-                $response->setError(401, 'invalid_token', 'The access token provided is invalid');
-            } elseif (!isset($token["expires"]) || !isset($token["client_id"])) {
-                $response->setError(401, 'malformed_token', 'Malformed token (missing "expires")');
-            } elseif (time() > $token["expires"]) {
-                $response->setError(401, 'expired_token', 'The access token provided has expired');
-            } else {
-                return $token;
-            }
+        $token_param = $this->tokenType->getAccessTokenParameter($request, $response);
+
+        // Get the stored token data (from the implementing subclass)
+        // Check we have a well formed token
+        // Check token expiration (expires is a mandatory paramter)
+        if (!$token = $this->tokenStorage->getAccessToken($token_param)) {
+            $response->setError(401, 'invalid_token', 'The access token provided is invalid');
+        } elseif (!isset($token["expires"]) || !isset($token["client_id"])) {
+            $response->setError(401, 'malformed_token', 'Malformed token (missing "expires")');
+        } elseif (time() > $token["expires"]) {
+            $response->setError(401, 'expired_token', 'The access token provided has expired');
+        } else {
+            return $token;
         }
 
         $authHeader = sprintf('%s realm="%s"', $this->tokenType->getTokenType(), $this->config['www_realm']);


### PR DESCRIPTION
When client make request without `access_token` $responce->send() return only 401 code of header and empty array. I think should validate this type of error.

Issue: https://github.com/bshaffer/oauth2-server-php/issues/560