### PR TITLE
Pass "issuer" config key when creating default JwtAccessToken

### DIFF
--- a/src/OAuth2/Server.php
+++ b/src/OAuth2/Server.php
@@ -692,7 +692,7 @@ class Server implements ResourceControllerInterface,
             $refreshStorage = $this->storages['refresh_token'];
         }
 
-        $config = array_intersect_key($this->config, array_flip(explode(' ', 'store_encrypted_token_string')));
+        $config = array_intersect_key($this->config, array_flip(explode(' ', 'store_encrypted_token_string issuer')));
 
         return new JwtAccessToken($this->storages['public_key'], $tokenStorage, $refreshStorage, $config);
     }


### PR DESCRIPTION
Fix for #562 