### PR TITLE
Updated JWT lib to address #564

### DIFF
--- a/src/OAuth2/Encryption/EncryptionInterface.php
+++ b/src/OAuth2/Encryption/EncryptionInterface.php
@@ -4,8 +4,9 @@ namespace OAuth2\Encryption;
 
 interface EncryptionInterface
 {
+    public function getSupportedAlgorithms($type = null);
     public function encode($payload, $key, $algorithm = null);
-    public function decode($payload, $key, $algorithm = null);
+    public function decode($payload, $key, $allowed_algorithms = null);
     public function urlSafeB64Encode($data);
     public function urlSafeB64Decode($b64);
 }

--- a/src/OAuth2/GrantType/JwtBearer.php
+++ b/src/OAuth2/GrantType/JwtBearer.php
@@ -78,7 +78,7 @@ class JwtBearer implements GrantTypeInterface, ClientAssertionTypeInterface
         $undecodedJWT = $request->request('assertion');
 
         // Decode the JWT
-        $jwt = $this->jwtUtil->decode($request->request('assertion'), null, false);
+        $jwt = $this->jwtUtil->decode($request->request('assertion'), null);
 
         if (!$jwt) {
             $response->setError(400, 'invalid_request', "JWT is malformed");
@@ -176,8 +176,10 @@ class JwtBearer implements GrantTypeInterface, ClientAssertionTypeInterface
             return null;
         }
 
+        // get the supported RSA algorithms from the jwtUtil
+        $allowed_algorithms = $this->jwtUtil->getSupportedAlgorithms('RSA');
         // Verify the JWT
-        if (!$this->jwtUtil->decode($undecodedJWT, $key, true)) {
+        if (!$this->jwtUtil->decode($undecodedJWT, $key, $allowed_algorithms)) {
             $response->setError(400, 'invalid_grant', "JWT failed signature verification");
 
             return null;

--- a/src/OAuth2/Storage/JwtAccessToken.php
+++ b/src/OAuth2/Storage/JwtAccessToken.php
@@ -35,7 +35,7 @@ class JwtAccessToken implements JwtAccessTokenInterface
     public function getAccessToken($oauth_token)
     {
         // just decode the token, don't verify
-        if (!$tokenData = $this->encryptionUtil->decode($oauth_token, null, false)) {
+        if (!$tokenData = $this->encryptionUtil->decode($oauth_token, null)) {
             return false;
         }
 
@@ -44,7 +44,7 @@ class JwtAccessToken implements JwtAccessTokenInterface
         $algorithm  = $this->publicKeyStorage->getEncryptionAlgorithm($client_id);
 
         // now that we have the client_id, verify the token
-        if (false === $this->encryptionUtil->decode($oauth_token, $public_key, true)) {
+        if (false === $this->encryptionUtil->decode($oauth_token, $public_key, array($algorithm))) {
             return false;
         }
 


### PR DESCRIPTION
`JWT::decode()` now takes an array of `$allowed_algorithms` to prevent tricking the server into decoding using a different algorithm than intended.

The only required change here is specifying the `$allowed_algorithms` parameter to the `JWT::decode()` method and updating calls to that function elsewhere.

However since the JWT Grant Type doesn't store the RSA algorithm alongside the public key (and it looked like a bit of work to do that), I've extended the JWT class to provide supported RSA methods using `JWT::getSupportedMethods($type)` and refactored the `JWT::sign()` and `JWT::verifySignature()` methods to use the `JWT::$supportedMethods` declaration. 

This sounds like a big change, but its essentially a copy of the `firebase/php-jwt` implementation and it just seemed cleaner to do it this way. If you would rather we sticked to what was there and only change the `JWT::decode()` method signature, we'll just need to hard-code the allowed RSA methods in `JWTBearer::validateRequest()`. I figured doing that would be non-obvious for future maintenance but happy to follow your lead on whatever you feel comfortable with.