### PR TITLE
Alternative implementation of JWT lib

### DIFF
--- a/src/OAuth2/Encryption/Jwt.php
+++ b/src/OAuth2/Encryption/Jwt.php
@@ -25,7 +25,7 @@ class Jwt implements EncryptionInterface
         return implode('.', $segments);
     }
 
-    public function decode($jwt, $key = null, $verify = true)
+    public function decode($jwt, $key = null, $allowedAlgorithms = true)
     {
         if (!strpos($jwt, '.')) {
             return false;
@@ -49,8 +49,13 @@ class Jwt implements EncryptionInterface
 
         $sig = $this->urlSafeB64Decode($cryptob64);
 
-        if ($verify) {
+        if ((bool) $allowedAlgorithms) {
             if (!isset($header['alg'])) {
+                return false;
+            }
+
+            // check if bool arg supplied here to maintain BC
+            if (is_array($allowedAlgorithms) && !in_array($header['alg'], $allowedAlgorithms)) {
                 return false;
             }
 

--- a/src/OAuth2/Storage/JwtAccessToken.php
+++ b/src/OAuth2/Storage/JwtAccessToken.php
@@ -44,7 +44,7 @@ class JwtAccessToken implements JwtAccessTokenInterface
         $algorithm  = $this->publicKeyStorage->getEncryptionAlgorithm($client_id);
 
         // now that we have the client_id, verify the token
-        if (false === $this->encryptionUtil->decode($oauth_token, $public_key, true)) {
+        if (false === $this->encryptionUtil->decode($oauth_token, $public_key, array($algorithm))) {
             return false;
         }
 

--- a/test/OAuth2/Encryption/JwtTest.php
+++ b/test/OAuth2/Encryption/JwtTest.php
@@ -45,8 +45,16 @@ EOD;
 
         $encoded = $jwtUtil->encode($params, $this->privateKey, 'RS256');
 
+        // test BC behaviour of trusting the algorithm in the header
         $payload = $jwtUtil->decode($encoded, $client_key);
+        $this->assertEquals($params, $payload);
 
+        // test BC behaviour of not verifying by passing false
+        $payload = $jwtUtil->decode($encoded, $client_key, false);
+        $this->assertEquals($params, $payload);
+
+        // test the new restricted algorithms header
+        $payload = $jwtUtil->decode($encoded, $client_key, array('RS256'));
         $this->assertEquals($params, $payload);
     }
 
@@ -56,6 +64,29 @@ EOD;
 
         $this->assertFalse($jwtUtil->decode('goob'));
         $this->assertFalse($jwtUtil->decode('go.o.b'));
+    }
+
+    /** @dataProvider provideClientCredentials */
+    public function testInvalidJwtHeader($client_id, $client_key)
+    {
+        $jwtUtil = new Jwt();
+
+        $params = array(
+            'iss' => $client_id,
+            'exp' => time() + 1000,
+            'iat' => time(),
+            'sub' => 'testuser@ourdomain.com',
+            'aud' => 'http://myapp.com/oauth/auth',
+            'scope' => null,
+        );
+
+        // testing for algorithm tampering when only RSA256 signing is allowed
+        // @see https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/
+        $tampered = $jwtUtil->encode($params, $client_key, 'HS256');
+
+        $payload = $jwtUtil->decode($tampered, $client_key, array('RS256'));
+
+        $this->assertFalse($payload);
     }
 
     public function provideClientCredentials()


### PR DESCRIPTION
An alternate patch to PR #567 that maintains backwards compatibility with existing interfaces, but is unsafe for users who call `JWT::decode` themselves without passing the allowed arguments array.

The allowed algorithms for the `JWTBearer` grant type are specified as an additional argument to the constructor, with defaults set if the argument is null.

Addresses #564.