### PR TITLE
Remove native JWT implementation and use firebase/php-jwt instead.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,6 @@ before_script:
 - composer require predis/predis:dev-master
 - composer require thobbs/phpcassa:dev-master
 - composer require aws/aws-sdk-php:dev-master
+- composer require firebase/php-jwt:dev-master
 after_script:
 - php test/cleanup.php

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "suggest": {
         "predis/predis": "Required to use the Redis storage engine",
         "thobbs/phpcassa": "Required to use the Cassandra storage engine",
-        "aws/aws-sdk-php": "Required to use the DynamoDB storage engine"
+        "aws/aws-sdk-php": "Required to use the DynamoDB storage engine",
+        "firebase/php-jwt": "Required to use JWT features"
     }
 }

--- a/src/OAuth2/Encryption/EncryptionInterface.php
+++ b/src/OAuth2/Encryption/EncryptionInterface.php
@@ -4,8 +4,9 @@ namespace OAuth2\Encryption;
 
 interface EncryptionInterface
 {
-    public function encode($payload, $key, $algorithm = null);
-    public function decode($payload, $key, $algorithm = null);
+    public function encode($payload, $key, $algorithm = null, $keyId = null);
+
+    public function decode($payload, $key, array $allowedAlgorithms = array());
     public function urlSafeB64Encode($data);
     public function urlSafeB64Decode($b64);
 }

--- a/src/OAuth2/Encryption/Jwt.php
+++ b/src/OAuth2/Encryption/Jwt.php
@@ -3,170 +3,35 @@
 namespace OAuth2\Encryption;
 
 /**
- * @link https://github.com/F21/jwt
- * @author F21
+ * Bridge file to use the firebase/php-jwt package for JWT encoding and decoding.
+ * @author Francis Chuang <francis.chuang@gmail.com>
  */
 class Jwt implements EncryptionInterface
 {
-    public function encode($payload, $key, $algo = 'HS256')
+    public function __construct()
     {
-        $header = $this->generateJwtHeader($payload, $algo);
-
-        $segments = array(
-            $this->urlSafeB64Encode(json_encode($header)),
-            $this->urlSafeB64Encode(json_encode($payload))
-        );
-
-        $signing_input = implode('.', $segments);
-
-        $signature = $this->sign($signing_input, $key, $algo);
-        $segments[] = $this->urlsafeB64Encode($signature);
-
-        return implode('.', $segments);
-    }
-
-    public function decode($jwt, $key = null, $allowedAlgorithms = true)
-    {
-        if (!strpos($jwt, '.')) {
-            return false;
-        }
-
-        $tks = explode('.', $jwt);
-
-        if (count($tks) != 3) {
-            return false;
-        }
-
-        list($headb64, $payloadb64, $cryptob64) = $tks;
-
-        if (null === ($header = json_decode($this->urlSafeB64Decode($headb64), true))) {
-            return false;
-        }
-
-        if (null === $payload = json_decode($this->urlSafeB64Decode($payloadb64), true)) {
-            return false;
-        }
-
-        $sig = $this->urlSafeB64Decode($cryptob64);
-
-        if ((bool) $allowedAlgorithms) {
-            if (!isset($header['alg'])) {
-                return false;
-            }
-
-            // check if bool arg supplied here to maintain BC
-            if (is_array($allowedAlgorithms) && !in_array($header['alg'], $allowedAlgorithms)) {
-                return false;
-            }
-
-            if (!$this->verifySignature($sig, "$headb64.$payloadb64", $key, $header['alg'])) {
-                return false;
-            }
-        }
-
-        return $payload;
-    }
-
-    private function verifySignature($signature, $input, $key, $algo = 'HS256')
-    {
-        // use constants when possible, for HipHop support
-        switch ($algo) {
-            case'HS256':
-            case'HS384':
-            case'HS512':
-                return $this->hash_equals(
-                    $this->sign($input, $key, $algo),
-                    $signature
-                );
-
-            case 'RS256':
-                return openssl_verify($input, $signature, $key, defined('OPENSSL_ALGO_SHA256') ? OPENSSL_ALGO_SHA256 : 'sha256')  === 1;
-
-            case 'RS384':
-                return @openssl_verify($input, $signature, $key, defined('OPENSSL_ALGO_SHA384') ? OPENSSL_ALGO_SHA384 : 'sha384') === 1;
-
-            case 'RS512':
-                return @openssl_verify($input, $signature, $key, defined('OPENSSL_ALGO_SHA512') ? OPENSSL_ALGO_SHA512 : 'sha512') === 1;
-
-            default:
-                throw new \InvalidArgumentException("Unsupported or invalid signing algorithm.");
+        if (!class_exists('\JWT')) {
+            throw new \ErrorException('firebase/php-jwt must be installed to use this feature. You can do this by running "composer require firebase/php-jwt"');
         }
     }
 
-    private function sign($input, $key, $algo = 'HS256')
+    public function encode($payload, $key, $alg = 'HS256', $keyId = null)
     {
-        switch ($algo) {
-            case 'HS256':
-                return hash_hmac('sha256', $input, $key, true);
-
-            case 'HS384':
-                return hash_hmac('sha384', $input, $key, true);
-
-            case 'HS512':
-                return hash_hmac('sha512', $input, $key, true);
-
-            case 'RS256':
-                return $this->generateRSASignature($input, $key, defined('OPENSSL_ALGO_SHA256') ? OPENSSL_ALGO_SHA256 : 'sha256');
-
-            case 'RS384':
-                return $this->generateRSASignature($input, $key, defined('OPENSSL_ALGO_SHA384') ? OPENSSL_ALGO_SHA384 : 'sha384');
-
-            case 'RS512':
-                return $this->generateRSASignature($input, $key, defined('OPENSSL_ALGO_SHA512') ? OPENSSL_ALGO_SHA512 : 'sha512');
-
-            default:
-                throw new \Exception("Unsupported or invalid signing algorithm.");
-        }
+        return \JWT::encode($payload, $key, $alg, $keyId);
     }
 
-    private function generateRSASignature($input, $key, $algo)
+    public function decode($jwt, $key = null, array $allowedAlgorithms = array())
     {
-        if (!openssl_sign($input, $signature, $key, $algo)) {
-            throw new \Exception("Unable to sign data.");
-        }
-
-        return $signature;
+        return (array)\JWT::decode($jwt, $key, $allowedAlgorithms);
     }
 
     public function urlSafeB64Encode($data)
     {
-        $b64 = base64_encode($data);
-        $b64 = str_replace(array('+', '/', "\r", "\n", '='),
-                array('-', '_'),
-                $b64);
-
-        return $b64;
+        return \JWT::urlsafeB64Encode($data);
     }
 
     public function urlSafeB64Decode($b64)
     {
-        $b64 = str_replace(array('-', '_'),
-                array('+', '/'),
-                $b64);
-
-        return base64_decode($b64);
-    }
-
-    /**
-     * Override to create a custom header
-     */
-    protected function generateJwtHeader($payload, $algorithm)
-    {
-        return array(
-            'typ' => 'JWT',
-            'alg' => $algorithm,
-        );
-    }
-    
-    protected function hash_equals($a, $b)
-    {
-        if (function_exists('hash_equals')) {
-            return hash_equals($a, $b);
-        }
-        $diff = strlen($a) ^ strlen($b);
-        for ($i = 0; $i < strlen($a) && $i < strlen($b); $i++) {
-            $diff |= ord($a[$i]) ^ ord($b[$i]);
-        }
-        return $diff === 0;
+        return \JWT::urlsafeB64Decode($b64);
     }
 }

--- a/src/OAuth2/GrantType/JwtBearer.php
+++ b/src/OAuth2/GrantType/JwtBearer.php
@@ -35,8 +35,12 @@ class JwtBearer implements GrantTypeInterface, ClientAssertionTypeInterface
      * @param EncryptionInterface|OAuth2\Encryption\JWT $jwtUtil OPTONAL The class used to decode, encode and verify JWTs.
      * @param array $config
      */
-    public function __construct(JwtBearerInterface $storage, $audience, EncryptionInterface $jwtUtil = null, array $config = array())
-    {
+    public function __construct(
+        JwtBearerInterface $storage,
+        $audience,
+        EncryptionInterface $jwtUtil = null,
+        array $config = array()
+    ) {
         $this->storage = $storage;
         $this->audience = $audience;
 
@@ -86,9 +90,9 @@ class JwtBearer implements GrantTypeInterface, ClientAssertionTypeInterface
         $undecodedJWT = $request->request('assertion');
 
         // Decode the JWT
-        $jwt = $this->jwtUtil->decode($request->request('assertion'), null, false);
-
-        if (!$jwt) {
+        try {
+            $jwt = $this->jwtUtil->decode($request->request('assertion'), null);
+        } catch (\Exception $e) {
             $response->setError(400, 'invalid_request', "JWT is malformed");
 
             return null;
@@ -185,7 +189,9 @@ class JwtBearer implements GrantTypeInterface, ClientAssertionTypeInterface
         }
 
         // Verify the JWT
-        if (!$this->jwtUtil->decode($undecodedJWT, $key, $this->allowedAlgorithms)) {
+        try {
+            $this->jwtUtil->decode($undecodedJWT, $key, $this->allowedAlgorithms);
+        } catch (\Exception $e) {
             $response->setError(400, 'invalid_grant', "JWT failed signature verification");
 
             return null;

--- a/src/OAuth2/Storage/JwtAccessToken.php
+++ b/src/OAuth2/Storage/JwtAccessToken.php
@@ -35,7 +35,9 @@ class JwtAccessToken implements JwtAccessTokenInterface
     public function getAccessToken($oauth_token)
     {
         // just decode the token, don't verify
-        if (!$tokenData = $this->encryptionUtil->decode($oauth_token, null, false)) {
+        try {
+            $tokenData = $this->encryptionUtil->decode($oauth_token, null);
+        } catch (\UnexpectedValueException $e) {
             return false;
         }
 
@@ -44,7 +46,9 @@ class JwtAccessToken implements JwtAccessTokenInterface
         $algorithm  = $this->publicKeyStorage->getEncryptionAlgorithm($client_id);
 
         // now that we have the client_id, verify the token
-        if (false === $this->encryptionUtil->decode($oauth_token, $public_key, array($algorithm))) {
+        try {
+            $tokenData = $this->encryptionUtil->decode($oauth_token, $public_key, array($algorithm));
+        } catch (\Exception $e) {
             return false;
         }
 

--- a/test/OAuth2/Encryption/JwtTest.php
+++ b/test/OAuth2/Encryption/JwtTest.php
@@ -45,28 +45,26 @@ EOD;
 
         $encoded = $jwtUtil->encode($params, $this->privateKey, 'RS256');
 
-        // test BC behaviour of trusting the algorithm in the header
-        $payload = $jwtUtil->decode($encoded, $client_key);
-        $this->assertEquals($params, $payload);
-
-        // test BC behaviour of not verifying by passing false
-        $payload = $jwtUtil->decode($encoded, $client_key, false);
-        $this->assertEquals($params, $payload);
-
         // test the new restricted algorithms header
         $payload = $jwtUtil->decode($encoded, $client_key, array('RS256'));
         $this->assertEquals($params, $payload);
     }
 
+    /**
+     * @expectedException \UnexpectedValueException
+     */
     public function testInvalidJwt()
     {
         $jwtUtil = new Jwt();
 
-        $this->assertFalse($jwtUtil->decode('goob'));
-        $this->assertFalse($jwtUtil->decode('go.o.b'));
+        $jwtUtil->decode('goob');
+        $jwtUtil->decode('go.o.b');
     }
 
-    /** @dataProvider provideClientCredentials */
+    /**
+     * @dataProvider provideClientCredentials
+     * @expectedException \DomainException
+     */
     public function testInvalidJwtHeader($client_id, $client_key)
     {
         $jwtUtil = new Jwt();
@@ -85,8 +83,6 @@ EOD;
         $tampered = $jwtUtil->encode($params, $client_key, 'HS256');
 
         $payload = $jwtUtil->decode($tampered, $client_key, array('RS256'));
-
-        $this->assertFalse($payload);
     }
 
     public function provideClientCredentials()

--- a/test/OAuth2/ResponseType/JwtAccessTokenTest.php
+++ b/test/OAuth2/ResponseType/JwtAccessTokenTest.php
@@ -21,7 +21,7 @@ class JwtAccessTokenTest extends \PHPUnit_Framework_TestCase
 
         $accessToken = $jwtResponseType->createAccessToken('Test Client ID', 123, 'test', false);
         $jwt = new Jwt;
-        $decodedAccessToken = $jwt->decode($accessToken['access_token'], null, false);
+        $decodedAccessToken = $jwt->decode($accessToken['access_token'], null);
 
         $this->assertArrayHasKey('id', $decodedAccessToken);
         $this->assertArrayHasKey('iss', $decodedAccessToken);


### PR DESCRIPTION
Added some compatibility code to maintain BC.

This is for `2.0` which should be using `firebase/php-jwt` going forward.
