### PR TITLE
Added support for revoking tokens

### DIFF
--- a/src/OAuth2/ResponseType/AccessToken.php
+++ b/src/OAuth2/ResponseType/AccessToken.php
@@ -154,4 +154,41 @@ class AccessToken implements AccessTokenInterface
     {
         return $this->generateAccessToken(); // let's reuse the same scheme for token generation
     }
+
+    /**
+     * Handle the revoking of refresh tokens, and access tokens if supported / desirable
+     * RFC7009 specifies that "If the server is unable to locate the token using
+     * the given hint, it MUST extend its search across all of its supported token types"
+     *
+     * @param $token
+     * @param null $tokenTypeHint
+     * @return boolean
+     */
+    public function revokeToken($token, $tokenTypeHint = null)
+    {
+        if ($tokenTypeHint == 'refresh_token') {
+            if ($this->refreshStorage && $revoked = $this->refreshStorage->unsetRefreshToken($token)) {
+                return true;
+            }
+        }
+
+        /** @TODO remove in v2 */
+        if (!method_exists($this->tokenStorage, 'unsetAccessToken')) {
+            throw new \RuntimeException(
+                sprintf('Token storage %s must implement unsetAccessToken method', get_class($this->tokenStorage)
+            ));
+        }
+
+        $revoked = $this->tokenStorage->unsetAccessToken($token);
+
+        // if a typehint is supplied and fails, try other storages 
+        // @see https://tools.ietf.org/html/rfc7009#section-2.1
+        if (!$revoked && $tokenTypeHint != 'refresh_token') {
+            if ($this->refreshStorage) {
+                $revoked = $this->refreshStorage->unsetRefreshToken($token);
+            }
+        }
+
+        return $revoked;
+    }
 }

--- a/src/OAuth2/ResponseType/AccessTokenInterface.php
+++ b/src/OAuth2/ResponseType/AccessTokenInterface.php
@@ -20,4 +20,15 @@ interface AccessTokenInterface extends ResponseTypeInterface
      * @ingroup oauth2_section_5
      */
     public function createAccessToken($client_id, $user_id, $scope = null, $includeRefreshToken = true);
+
+    /**
+     * Handle the revoking of refresh tokens, and access tokens if supported / desirable
+     *
+     * @param $token
+     * @param $tokenTypeHint
+     * @return mixed
+     *
+     * @todo v2.0 include this method in interface. Omitted to maintain BC in v1.x
+     */
+    //public function revokeToken($token, $tokenTypeHint);
 }

--- a/src/OAuth2/Server.php
+++ b/src/OAuth2/Server.php
@@ -270,6 +270,24 @@ class Server implements ResourceControllerInterface,
     }
 
     /**
+     * Handle a revoke token request
+     * This would be called from the "/revoke" endpoint as defined in the draft Token Revocation spec
+     *
+     * @see https://tools.ietf.org/html/rfc7009#section-2
+     *
+     * @param RequestInterface $request
+     * @param ResponseInterface $response
+     * @return Response|ResponseInterface
+     */
+    public function handleRevokeRequest(RequestInterface $request, ResponseInterface $response = null)
+    {
+        $this->response = is_null($response) ? new Response() : $response;
+        $this->getTokenController()->handleRevokeRequest($request, $this->response);
+
+        return $this->response;
+    }
+
+    /**
      * Redirect the user appropriately after approval.
      *
      * After the user has approved or denied the resource request the

--- a/src/OAuth2/Storage/AccessTokenInterface.php
+++ b/src/OAuth2/Storage/AccessTokenInterface.php
@@ -45,4 +45,19 @@ interface AccessTokenInterface
      * @ingroup oauth2_section_4
      */
     public function setAccessToken($oauth_token, $client_id, $user_id, $expires, $scope = null);
+
+    /**
+     * Expire an access token.
+     *
+     * This is not explicitly required in the spec, but if defined in a draft RFC for token
+     * revoking (RFC 7009) https://tools.ietf.org/html/rfc7009
+     *
+     * @param $access_token
+     * Access token to be expired.
+     *
+     * @ingroup oauth2_section_6
+     *
+     * @todo v2.0 include this method in interface. Omitted to maintain BC in v1.x
+     */
+    //public function unsetAccessToken($access_token);
 }

--- a/src/OAuth2/Storage/Cassandra.php
+++ b/src/OAuth2/Storage/Cassandra.php
@@ -294,6 +294,11 @@ class Cassandra implements AuthorizationCodeInterface,
         );
     }
 
+    public function unsetAccessToken($access_token)
+    {
+        return $this->expireValue($this->config['access_token_key'] . $access_token);
+    }
+
     /* ScopeInterface */
     public function scopeExists($scope)
     {

--- a/src/OAuth2/Storage/DynamoDB.php
+++ b/src/OAuth2/Storage/DynamoDB.php
@@ -182,6 +182,16 @@ class DynamoDB implements
 
     }
 
+    public function unsetAccessToken($access_token)
+    {
+        $result = $this->client->deleteItem(array(
+            'TableName' =>  $this->config['access_token_table'],
+            'Key' => $this->client->formatAttributes(array("access_token" => $access_token))
+        ));
+
+        return true;
+    }
+
     /* OAuth2\Storage\AuthorizationCodeInterface */
     public function getAuthorizationCode($code)
     {

--- a/src/OAuth2/Storage/JwtAccessToken.php
+++ b/src/OAuth2/Storage/JwtAccessToken.php
@@ -59,6 +59,14 @@ class JwtAccessToken implements JwtAccessTokenInterface
         }
     }
 
+    public function unsetAccessToken($access_token)
+    {
+        if ($this->tokenStorage) {
+            return $this->tokenStorage->unsetAccessToken($access_token);
+        }
+    }
+
+
     // converts a JWT access token into an OAuth2-friendly format
     protected function convertJwtToOAuth2($tokenData)
     {

--- a/src/OAuth2/Storage/Memory.php
+++ b/src/OAuth2/Storage/Memory.php
@@ -257,6 +257,11 @@ class Memory implements AuthorizationCodeInterface,
         return true;
     }
 
+    public function unsetAccessToken($access_token)
+    {
+        unset($this->accessTokens[$access_token]);
+    }
+
     public function scopeExists($scope)
     {
         $scope = explode(' ', trim($scope));

--- a/src/OAuth2/Storage/Mongo.php
+++ b/src/OAuth2/Storage/Mongo.php
@@ -161,6 +161,12 @@ class Mongo implements AuthorizationCodeInterface,
         return true;
     }
 
+    public function unsetAccessToken($access_token)
+    {
+        $this->collection('access_token_table')->remove(array('access_token' => $access_token));
+    }
+
+
     /* AuthorizationCodeInterface */
     public function getAuthorizationCode($code)
     {

--- a/src/OAuth2/Storage/Pdo.php
+++ b/src/OAuth2/Storage/Pdo.php
@@ -156,6 +156,13 @@ class Pdo implements
         return $stmt->execute(compact('access_token', 'client_id', 'user_id', 'expires', 'scope'));
     }
 
+    public function unsetAccessToken($access_token)
+    {
+        $stmt = $this->db->prepare(sprintf('DELETE FROM %s WHERE access_token = :access_token', $this->config['access_token_table']));
+
+        return $stmt->execute(compact('access_token'));
+    }
+
     /* OAuth2\Storage\AuthorizationCodeInterface */
     public function getAuthorizationCode($code)
     {

--- a/src/OAuth2/Storage/Redis.php
+++ b/src/OAuth2/Storage/Redis.php
@@ -227,6 +227,11 @@ class Redis implements AuthorizationCodeInterface,
         );
     }
 
+    public function unsetAccessToken($access_token)
+    {
+        return $this->expireValue($this->config['access_token_key'] . $access_token);
+    }
+
     /* ScopeInterface */
     public function scopeExists($scope)
     {

--- a/test/OAuth2/Controller/TokenControllerTest.php
+++ b/test/OAuth2/Controller/TokenControllerTest.php
@@ -223,6 +223,54 @@ class TokenControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($response->getParameter('token_type'));
     }
 
+    public function testInvalidTokenTypeHintForRevoke()
+    {
+        $server = $this->getTestServer();
+
+        $request = TestRequest::createPost(array(
+            'token_type_hint' => 'foo',
+            'token' => 'sometoken'
+        ));
+
+        $server->handleRevokeRequest($request, $response = new Response());
+
+        $this->assertTrue($response instanceof Response);
+        $this->assertEquals(400, $response->getStatusCode(), var_export($response, 1));
+        $this->assertEquals($response->getParameter('error'), 'invalid_request');
+        $this->assertEquals($response->getParameter('error_description'), 'Token type hint must be either \'access_token\' or \'refresh_token\'');
+    }
+
+    public function testMissingTokenForRevoke()
+    {
+        $server = $this->getTestServer();
+
+        $request = TestRequest::createPost(array(
+            'token_type_hint' => 'access_token'
+        ));
+
+        $server->handleRevokeRequest($request, $response = new Response());
+        $this->assertTrue($response instanceof Response);
+        $this->assertEquals(400, $response->getStatusCode(), var_export($response, 1));
+        $this->assertEquals($response->getParameter('error'), 'invalid_request');
+        $this->assertEquals($response->getParameter('error_description'), 'Missing token parameter to revoke');
+    }
+
+    public function testInvalidRequestMethodForRevoke()
+    {
+        $server = $this->getTestServer();
+
+        $request = new TestRequest();
+        $request->setQuery(array(
+            'token_type_hint' => 'access_token'
+        ));
+
+        $server->handleRevokeRequest($request, $response = new Response());
+        $this->assertTrue($response instanceof Response);
+        $this->assertEquals(405, $response->getStatusCode(), var_export($response, 1));
+        $this->assertEquals($response->getParameter('error'), 'invalid_request');
+        $this->assertEquals($response->getParameter('error_description'), 'The request method must be POST when revoking an access token');
+    }
+
     public function testCreateController()
     {
         $storage = Bootstrap::getInstance()->getMemoryStorage();

--- a/test/OAuth2/ResponseType/AccessTokenTest.php
+++ b/test/OAuth2/ResponseType/AccessTokenTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace OAuth2\ResponseType;
+
+use OAuth2\Server;
+use OAuth2\Storage\Memory;
+
+class AccessTokenTest extends \PHPUnit_Framework_TestCase
+{
+    public function testRevokeAccessTokenWithTypeHint()
+    {
+        $tokenStorage = new Memory(array(
+            'access_tokens' => array(
+                'revoke' => array('mytoken'),
+            ),
+        ));
+
+        $this->assertEquals(array('mytoken'), $tokenStorage->getAccessToken('revoke'));
+        $accessToken = new AccessToken($tokenStorage);
+        $accessToken->revokeToken('revoke', 'access_token');
+        $this->assertFalse($tokenStorage->getAccessToken('revoke'));
+    }
+
+    public function testRevokeAccessTokenWithoutTypeHint()
+    {
+        $tokenStorage = new Memory(array(
+            'access_tokens' => array(
+                'revoke' => array('mytoken'),
+            ),
+        ));
+
+        $this->assertEquals(array('mytoken'), $tokenStorage->getAccessToken('revoke'));
+        $accessToken = new AccessToken($tokenStorage);
+        $accessToken->revokeToken('revoke');
+        $this->assertFalse($tokenStorage->getAccessToken('revoke'));
+    }
+
+    public function testRevokeRefreshTokenWithTypeHint()
+    {
+        $tokenStorage = new Memory(array(
+            'refresh_tokens' => array(
+                'revoke' => array('mytoken'),
+            ),
+        ));
+
+        $this->assertEquals(array('mytoken'), $tokenStorage->getRefreshToken('revoke'));
+        $accessToken = new AccessToken(new Memory, $tokenStorage);
+        $accessToken->revokeToken('revoke', 'refresh_token');
+        $this->assertFalse($tokenStorage->getRefreshToken('revoke'));
+    }
+
+    public function testRevokeRefreshTokenWithoutTypeHint()
+    {
+        $tokenStorage = new Memory(array(
+            'refresh_tokens' => array(
+                'revoke' => array('mytoken'),
+            ),
+        ));
+
+        $this->assertEquals(array('mytoken'), $tokenStorage->getRefreshToken('revoke'));
+        $accessToken = new AccessToken(new Memory, $tokenStorage);
+        $accessToken->revokeToken('revoke');
+        $this->assertFalse($tokenStorage->getRefreshToken('revoke'));
+    }
+
+    public function testRevokeAccessTokenWithRefreshTokenTypeHint()
+    {
+        $tokenStorage = new Memory(array(
+            'access_tokens' => array(
+                'revoke' => array('mytoken'),
+            ),
+        ));
+
+        $this->assertEquals(array('mytoken'), $tokenStorage->getAccessToken('revoke'));
+        $accessToken = new AccessToken($tokenStorage);
+        $accessToken->revokeToken('revoke', 'refresh_token');
+        $this->assertFalse($tokenStorage->getAccessToken('revoke'));
+    }
+
+    public function testRevokeAccessTokenWithBogusTypeHint()
+    {
+        $tokenStorage = new Memory(array(
+            'access_tokens' => array(
+                'revoke' => array('mytoken'),
+            ),
+        ));
+
+        $this->assertEquals(array('mytoken'), $tokenStorage->getAccessToken('revoke'));
+        $accessToken = new AccessToken($tokenStorage);
+        $accessToken->revokeToken('revoke', 'foo');
+        $this->assertFalse($tokenStorage->getAccessToken('revoke'));
+    }
+
+    public function testRevokeRefreshTokenWithBogusTypeHint()
+    {
+        $tokenStorage = new Memory(array(
+            'refresh_tokens' => array(
+                'revoke' => array('mytoken'),
+            ),
+        ));
+
+        $this->assertEquals(array('mytoken'), $tokenStorage->getRefreshToken('revoke'));
+        $accessToken = new AccessToken(new Memory, $tokenStorage);
+        $accessToken->revokeToken('revoke', 'foo');
+        $this->assertFalse($tokenStorage->getRefreshToken('revoke'));
+    }
+}

--- a/test/OAuth2/Storage/AccessTokenTest.php
+++ b/test/OAuth2/Storage/AccessTokenTest.php
@@ -54,4 +54,29 @@ class AccessTokenTest extends BaseTest
         $success = $storage->setAccessToken('newtoken', 'client ID', 'SOMEOTHERID', $expires, '');
         $this->assertTrue($success);
     }
+
+    /** @dataProvider provideStorage */
+    public function testUnsetAccessToken(AccessTokenInterface $storage)
+    {
+        if ($storage instanceof NullStorage || !method_exists($storage, 'unsetAccessToken')) {
+            $this->markTestSkipped('Skipped Storage: ' . $storage->getMessage());
+
+            return;
+        }
+
+        // assert token we are unset does not exist
+        $token = $storage->getAccessToken('revokabletoken');
+        $this->assertFalse($token);
+
+        // add new token
+        $expires = time() + 20;
+        $success = $storage->setAccessToken('revokabletoken', 'client ID', 'SOMEUSERID', $expires);
+        $this->assertTrue($success);
+
+        $storage->unsetAccessToken('revokabletoken');
+
+        // assert token we are unset does not exist
+        $token = $storage->getAccessToken('revokabletoken');
+        $this->assertFalse($token);
+    }
 }


### PR DESCRIPTION
Implementation follows the Draft [RFC7009](https://tools.ietf.org/html/rfc7009) OAuth 2.0 Token Revocation.

Essentially adds a unsetAccessToken method to all the storage objects, and exposes a revoke endpoint on controllers. The only interesting thing is the `ResponseType\AccessToken::revokeToken()` method which has to check all token types if the specified type doesn't exist.

This goes some of the way to addressing #345, (adds `unsetAccessToken` methods etc), but doesn't account for bulk revoking of all tokens against a client or user. For this I've just extended the built-in storage class in our implementation and added the appropriate queries for doing the bulk stuff myself.

@bshaffer I'm not sure the tests I've done are comprehensive enough, can you cast your eye over and let me know if you'd like more in a certain area.