### PR TITLE
Allow configurable access_lifetime and refresh_token_lifetime for default JWT tokens

### DIFF
--- a/src/OAuth2/Server.php
+++ b/src/OAuth2/Server.php
@@ -693,7 +693,7 @@ class Server implements ResourceControllerInterface,
             $refreshStorage = $this->storages['refresh_token'];
         }
 
-        $config = array_intersect_key($this->config, array_flip(explode(' ', 'store_encrypted_token_string issuer')));
+        $config = array_intersect_key($this->config, array_flip(explode(' ', 'store_encrypted_token_string issuer access_lifetime refresh_token_lifetime')));
 
         return new JwtAccessToken($this->storages['public_key'], $tokenStorage, $refreshStorage, $config);
     }


### PR DESCRIPTION
This PR helps to make this happen...

    $server = new OAuth2\Server($storage, array(
        'always_issue_new_refresh_token' => true,
        'access_lifetime' => 316,
        'refresh_token_lifetime' => 499, // @todo configurize
        'use_jwt_access_tokens' => true
    ));

Or am I just doing it wrong?