### PR TITLE
Allow configurable access_lifetime and refresh_token_lifetime for default JWT tokens

### DIFF
--- a/src/OAuth2/Server.php
+++ b/src/OAuth2/Server.php
@@ -693,7 +693,7 @@ class Server implements ResourceControllerInterface,
             $refreshStorage = $this->storages['refresh_token'];
         }
 
-        $config = array_intersect_key($this->config, array_flip(explode(' ', 'store_encrypted_token_string issuer')));
+        $config = array_intersect_key($this->config, array_flip(explode(' ', 'store_encrypted_token_string issuer access_lifetime refresh_token_lifetime')));
 
         return new JwtAccessToken($this->storages['public_key'], $tokenStorage, $refreshStorage, $config);
     }


### PR DESCRIPTION
Allows the default access_lifetime and refresh_token_lifetime values to be overriden when default JWT tokens are implied in the following OAuth2\Server configuration

```
$server = new OAuth2\Server($storage, array(
    'always_issue_new_refresh_token' => true,
    'access_lifetime' => 316,
    'refresh_token_lifetime' => 499,
    'use_jwt_access_tokens' => true
));
```

Without this patch the specified access_lifetime and refresh_token_lifetime values is ignored