### PR TITLE
Class that implements MemCache support, MemCache is a prerequisite

### DIFF
--- a/src/OAuth2/Storage/MemCacheToken.php
+++ b/src/OAuth2/Storage/MemCacheToken.php
@@ -1,0 +1,51 @@
+<?php
+namespace OAuth2\Storage;
+
+use Memcache;
+
+class MemCacheToken implements AccessTokenInterface
+{
+    protected $storage;
+    protected $memcache;
+
+    public function __construct(AccessTokenInterface $storage)
+    {
+        $this->storage = $storage;
+
+        $this->memcache = new Memcache;
+        $this->memcache->connect('localhost', 11211);
+    }
+
+    public function getAccessToken($access_token)
+    {
+        $cacheKey = 'storage-'.$access_token;           
+
+        # Try and get from memory
+        $accessToken = $this->memcache->get($cacheKey);
+
+        # We have some data
+        if(!empty($accessToken)) {
+            return $accessToken;
+        }
+
+        $accessToken = $this->storage->getAccessToken('access_token');
+        $this->memcache->set($cacheKey, $accessToken, 0, strtotime($accessToken['expires']));
+
+        return $accessToken;
+    }
+
+    public function setAccessToken($oauth_token, $client_id, $user_id, $expires, $scope = null)
+    {
+        $cacheKey = 'storage-'.$oauth_token;           
+
+        $this->storage->setAccessToken($oauth_token, $client_id, $user_id, $expires, $scope);
+        $updatedAccessToken = $this->storage->getAccessToken($oauth_token);
+
+        $result = $this->memcache->replace($cacheKey, $updatedAccessToken, 0, $expires);
+        if( $result == false ) 
+        { 
+            $result = $this->memcache->set($cacheKey, $updatedAccessToken, 0, $expires);
+        }
+
+    }
+}


### PR DESCRIPTION
Guys I want to contribute with this, is a way to use MemCache to store your access token, this way the speed up is up to 10 times better than using PDO like mysql. I have used it for at least 1 year in a production server and it works like a charm :), we did comparasion test using apache benchmark only asking for already stored access token on mysql and the times are much better using memcache.

The good thing about it is that it does not matter which Storage you choose you can use anyone of the existing ones in oauth2-server and use MemCache with it.

To use it, an example:

```php
try {
			$pdotokenStorage = new OAuth2\Storage\Pdo(array('dsn' => $dsn, 'username' => $username, 'password' => $password));
		}catch(PDOException $e) {
			$this->_sendResponse(500, json_encode(array ('status'=> 500, 'message'=> 'Error interno en el servidor al conectar a la base se envio mail al administrador', 'code'=> 20003)), array('Content-type'   => 'application/json') );
		}
		// USING PDO-MEMCACHE
		$tokenStorage = new OAuth2\Storage\MemCacheToken($pdotokenStorage);
       

                $this->server = new OAuth2\Server($storage, array(
													    'always_issue_new_refresh_token' => true,
													    'refresh_token_lifetime'         => 2419200,
													) 
										 );

		
		// add the grant type to your OAuth server
		$this->server->addGrantType($grantType);

		$this->server->addStorage($tokenStorage, 'access_token');
```

