### PR TITLE
Added support for table prefixes to PDO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ To see the files changed for a given bug, go to https://github.com/bshaffer/oaut
 To get the diff between two versions, go to https://github.com/bshaffer/oauth2-server-php/compare/v1.0...v1.1
 To get the diff for a specific change, go to https://github.com/bshaffer/oauth2-server-php/commit/XXX where XXX is the change hash
 
+* 1.8.0 (2015-09-18)
+
+  PR: https://github.com/bshaffer/oauth2-server-php/pull/643
+
+  * bug #594 - adds jti
+  * bug #598 - fixes lifetime configurations for JWTs
+  * bug #634 - fixes travis builds, upgrade to containers
+  * bug #586 - support for revoking tokens
+  * bug #636 - Adds FirebaseJWT bridge
+  * bug #639 - Mongo HHVM compatibility
+
 * 1.7.0 (2015-04-23)
 
   PR: https://github.com/bshaffer/oauth2-server-php/pull/572

--- a/src/OAuth2/Storage/Pdo.php
+++ b/src/OAuth2/Storage/Pdo.php
@@ -57,17 +57,20 @@ class Pdo implements
         // debugging
         $connection->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
 
+        $prefix = getenv('OAUTH_SERVER_TABLE_PREFIX') ? getenv('OAUTH_SERVER_TABLE_PREFIX') : '';
+
         $this->config = array_merge(array(
-            'client_table' => 'oauth_clients',
-            'access_token_table' => 'oauth_access_tokens',
-            'refresh_token_table' => 'oauth_refresh_tokens',
-            'code_table' => 'oauth_authorization_codes',
-            'user_table' => 'oauth_users',
-            'jwt_table'  => 'oauth_jwt',
-            'jti_table'  => 'oauth_jti',
-            'scope_table'  => 'oauth_scopes',
-            'public_key_table'  => 'oauth_public_keys',
+            'client_table' => $prefix . 'oauth_clients',
+            'access_token_table' => $prefix . 'oauth_access_tokens',
+            'refresh_token_table' => $prefix . 'oauth_refresh_tokens',
+            'code_table' => $prefix . 'oauth_authorization_codes',
+            'user_table' => $prefix . 'oauth_users',
+            'jwt_table'  => $prefix . 'oauth_jwt',
+            'jti_table'  => $prefix . 'oauth_jti',
+            'scope_table'  => $prefix . 'oauth_scopes',
+            'public_key_table'  => $prefix . 'oauth_public_keys',
         ), $config);
+
     }
 
     /* OAuth2\Storage\ClientCredentialsInterface */


### PR DESCRIPTION
This is a simple but very useful feature that I think demand not only by me.

It can also be done through the environment variable, then it definitely will not break anything around. I wrote this patch for PDO and if you take it, I will be very grateful to you.

I could use a fork of your project, but then there will be further problems with its support from my side.

Thanking you in advance!