### PR TITLE
Feature/fix arround oidc spec

### DIFF
--- a/src/OAuth2/Controller/TokenController.php
+++ b/src/OAuth2/Controller/TokenController.php
@@ -51,7 +51,8 @@ class TokenController implements TokenControllerInterface
             // server MUST disable caching in headers when tokens are involved
             $response->setStatusCode(200);
             $response->addParameters($token);
-            $response->addHttpHeaders(array('Cache-Control' => 'no-store', 'Pragma' => 'no-cache'));
+            $response->addHttpHeaders(array('Cache-Control' => 'no-store', 'Pragma' => 'no-cache',
+                'Content-Type' => 'application/json'));
         }
     }
 

--- a/src/OAuth2/OpenID/ResponseType/IdToken.php
+++ b/src/OAuth2/OpenID/ResponseType/IdToken.php
@@ -6,6 +6,7 @@ use OAuth2\Encryption\EncryptionInterface;
 use OAuth2\Encryption\Jwt;
 use OAuth2\Storage\PublicKeyInterface;
 use OAuth2\OpenID\Storage\UserClaimsInterface;
+use Phalcon\Logger;
 
 class IdToken implements IdTokenInterface
 {
@@ -84,7 +85,7 @@ class IdToken implements IdTokenInterface
         // maps HS256 and RS256 to sha256, etc.
         $algorithm = $this->publicKeyStorage->getEncryptionAlgorithm($client_id);
         $hash_algorithm = 'sha' . substr($algorithm, 2);
-        $hash = hash($hash_algorithm, $access_token);
+        $hash = hash($hash_algorithm, $access_token, true);
         $at_hash = substr($hash, 0, strlen($hash) / 2);
 
         return $this->encryptionUtil->urlSafeB64Encode($at_hash);

--- a/src/OAuth2/OpenID/ResponseType/IdToken.php
+++ b/src/OAuth2/OpenID/ResponseType/IdToken.php
@@ -6,7 +6,6 @@ use OAuth2\Encryption\EncryptionInterface;
 use OAuth2\Encryption\Jwt;
 use OAuth2\Storage\PublicKeyInterface;
 use OAuth2\OpenID\Storage\UserClaimsInterface;
-use Phalcon\Logger;
 
 class IdToken implements IdTokenInterface
 {


### PR DESCRIPTION
Fix for pass test of http://openid.net/certification/testing/

* HTTP Response of TokenEndpoint should return application/json Content-Type
* fix at_hash computation in IdToken.