### PR TITLE
ResponseType sends user_info and not user_id to setAuthorizationCode

### DIFF
--- a/src/OAuth2/OpenID/ResponseType/AuthorizationCode.php
+++ b/src/OAuth2/OpenID/ResponseType/AuthorizationCode.php
@@ -16,14 +16,14 @@ class AuthorizationCode extends BaseAuthorizationCode implements AuthorizationCo
         parent::__construct($storage, $config);
     }
 
-    public function getAuthorizeResponse($params, $user_id = null)
+    public function getAuthorizeResponse($params, $userInfo = null)
     {
         // build the URL to redirect to
         $result = array('query' => array());
 
         $params += array('scope' => null, 'state' => null, 'id_token' => null);
 
-        $result['query']['code'] = $this->createAuthorizationCode($params['client_id'], $user_id, $params['redirect_uri'], $params['scope'], $params['id_token']);
+        $result['query']['code'] = $this->createAuthorizationCode($params['client_id'], $userInfo, $params['redirect_uri'], $params['scope'], $params['id_token']);
 
         if (isset($params['state'])) {
             $result['query']['state'] = $params['state'];
@@ -37,7 +37,7 @@ class AuthorizationCode extends BaseAuthorizationCode implements AuthorizationCo
      *
      * @param $client_id
      * Client identifier related to the authorization code
-     * @param $user_id
+     * @param $userInfo
      * User ID associated with the authorization code
      * @param $redirect_uri
      * An absolute URI to which the authorization server will redirect the
@@ -50,9 +50,11 @@ class AuthorizationCode extends BaseAuthorizationCode implements AuthorizationCo
      * @see http://tools.ietf.org/html/rfc6749#section-4
      * @ingroup oauth2_section_4
      */
-    public function createAuthorizationCode($client_id, $user_id, $redirect_uri, $scope = null, $id_token = null)
+    public function createAuthorizationCode($client_id, $userInfo, $redirect_uri, $scope = null, $id_token = null)
     {
         $code = $this->generateAuthorizationCode();
+
+        list($user_id, $auth_time) = $this->getUserIdAndAuthTime($userInfo);
         $this->storage->setAuthorizationCode($code, $client_id, $user_id, $redirect_uri, time() + $this->config['auth_code_lifetime'], $scope, $id_token);
 
         return $code;

--- a/src/OAuth2/OpenID/ResponseType/IdToken.php
+++ b/src/OAuth2/OpenID/ResponseType/IdToken.php
@@ -98,7 +98,7 @@ class IdToken implements IdTokenInterface
         return $this->encryptionUtil->encode($token, $private_key, $algorithm);
     }
 
-    private function getUserIdAndAuthTime($userInfo)
+    protected function getUserIdAndAuthTime($userInfo)
     {
         $auth_time = null;
 

--- a/src/OAuth2/ResponseType/AuthorizationCode.php
+++ b/src/OAuth2/ResponseType/AuthorizationCode.php
@@ -22,14 +22,14 @@ class AuthorizationCode implements AuthorizationCodeInterface
         ), $config);
     }
 
-    public function getAuthorizeResponse($params, $user_id = null)
+    public function getAuthorizeResponse($params, $userInfo = null)
     {
         // build the URL to redirect to
         $result = array('query' => array());
 
         $params += array('scope' => null, 'state' => null);
 
-        $result['query']['code'] = $this->createAuthorizationCode($params['client_id'], $user_id, $params['redirect_uri'], $params['scope']);
+        $result['query']['code'] = $this->createAuthorizationCode($params['client_id'], $userInfo, $params['redirect_uri'], $params['scope']);
 
         if (isset($params['state'])) {
             $result['query']['state'] = $params['state'];
@@ -43,7 +43,7 @@ class AuthorizationCode implements AuthorizationCodeInterface
      *
      * @param $client_id
      * Client identifier related to the authorization code
-     * @param $user_id
+     * @param $userInfo
      * User ID associated with the authorization code
      * @param $redirect_uri
      * An absolute URI to which the authorization server will redirect the
@@ -54,9 +54,11 @@ class AuthorizationCode implements AuthorizationCodeInterface
      * @see http://tools.ietf.org/html/rfc6749#section-4
      * @ingroup oauth2_section_4
      */
-    public function createAuthorizationCode($client_id, $user_id, $redirect_uri, $scope = null)
+    public function createAuthorizationCode($client_id, $userInfo, $redirect_uri, $scope = null)
     {
         $code = $this->generateAuthorizationCode();
+
+        list($user_id, $auth_time) = $this->getUserIdAndAuthTime($userInfo);
         $this->storage->setAuthorizationCode($code, $client_id, $user_id, $redirect_uri, time() + $this->config['auth_code_lifetime'], $scope);
 
         return $code;
@@ -96,5 +98,29 @@ class AuthorizationCode implements AuthorizationCodeInterface
         }
 
         return substr(hash('sha512', $randomData), 0, $tokenLen);
+    }
+
+    protected function getUserIdAndAuthTime($userInfo)
+    {
+        $auth_time = null;
+
+        // support an array for user_id / auth_time
+        if (is_array($userInfo)) {
+            if (!isset($userInfo['user_id'])) {
+                throw new \LogicException('if $user_id argument is an array, user_id index must be set');
+            }
+
+            $auth_time = isset($userInfo['auth_time']) ? $userInfo['auth_time'] : null;
+            $user_id = $userInfo['user_id'];
+        } else {
+            $user_id = $userInfo;
+        }
+
+        if (is_null($auth_time)) {
+            $auth_time = time();
+        }
+
+        // userInfo is a scalar, and so this is the $user_id. Auth Time is null
+        return array($user_id, $auth_time);
     }
 }

--- a/test/OAuth2/Controller/AuthorizeControllerTest.php
+++ b/test/OAuth2/Controller/AuthorizeControllerTest.php
@@ -10,6 +10,7 @@ use OAuth2\GrantType\AuthorizationCode;
 use OAuth2\Request;
 use OAuth2\Response;
 use OAuth2\Request\TestRequest;
+use OAuth2\Encryption\Jwt;
 
 class AuthorizeControllerTest extends \PHPUnit_Framework_TestCase
 {
@@ -414,6 +415,43 @@ class AuthorizeControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(isset($parmas['fake']));
         $this->assertArrayHasKey('state', $query);
         $this->assertEquals($query['state'], 'test');
+    }
+
+    public function testValidateAuthorizaitionCodeWhenUsingAuthTime()
+    {
+        $jwt = new Jwt();
+        $server = $this->getTestServer();
+
+        $response = new Response();
+        $request = new Request(array(
+            'client_id'     => 'Test Client ID', // valid client id
+            'redirect_uri'  => 'http://adobe.com', // valid redirect URI
+            'response_type' => 'code',
+            'scope'         => 'openid',
+            'state'         => 'af0ifjsldkj',
+            'nonce'         => 'n-0S6_WzA2Mj',
+        ));
+
+        // Test valid id_token request
+        $user_info = array(
+            'user_id' => 'testuser',
+            'auth_time' => time()-100,
+            );
+        $server->handleAuthorizeRequest($request, $response, true, $user_info);
+
+        $this->assertEquals($response->getStatusCode(), 302);
+
+        $parts = parse_url($response->getHttpHeader('Location'));
+        parse_str($parts['query'], $query);
+
+        $authCode = $server->getStorage('authorization_code')->getAuthorizationCode( $query['code'] );
+
+        $this->assertEquals('Test Client ID', $authCode['client_id']);
+        $this->assertEquals($user_info['user_id'], $authCode['user_id']);
+        $this->assertEquals('http://adobe.com', $authCode['redirect_uri']);
+        $this->assertGreaterThan(time(), $authCode['expires']);
+        $this->assertEquals('openid', $authCode['scope']);
+        $this->assertEmpty($authCode['id_token']);
     }
 
     public function testSuccessfulOpenidConnectRequest()


### PR DESCRIPTION
ResponseType\AuthorizationCode send the user_info (array with auth_time) directly to setAuthorizationCode instead of only sending $user_info['user_id'].

For the Storage\Memory none of the old tests detected this flaw, since 'user_id' is never used from getAuthorizationCode, but for eg. Storage\Pdo it always puts "Array" as user_id in the database.