### PR TITLE
make access token contain user identifier

### DIFF
--- a/src/OAuth2/ResponseType/AccessToken.php
+++ b/src/OAuth2/ResponseType/AccessToken.php
@@ -78,7 +78,8 @@ class AccessToken implements AccessTokenInterface
             "access_token" => $this->generateAccessToken(),
             "expires_in" => $this->config['access_lifetime'],
             "token_type" => $this->config['token_type'],
-            "scope" => $scope
+            "scope" => $scope,
+            "user_id" => $user_id,
         );
 
         $this->tokenStorage->setAccessToken($token["access_token"], $client_id, $user_id, $this->config['access_lifetime'] ? time() + $this->config['access_lifetime'] : null, $scope);


### PR DESCRIPTION
If a user gets authenticated by a client the client should get the user identifier.

For example I have an endpoint to get user information `https://api.example.com/user/` returning a list of users as well as `https://api.example.com/user/:id` returning information of one user only, but there is no endpoint returning only the current authenticated user.

So if the client directly receives the user identifier it can call `https://api.example.com/user/:id` to get additional information and it would match the one endpoint per resource principle.