### PR TITLE
Don't return claims with `null` value

### DIFF
--- a/src/OAuth2/OpenID/Storage/UserClaimsInterface.php
+++ b/src/OAuth2/OpenID/Storage/UserClaimsInterface.php
@@ -18,7 +18,7 @@ interface UserClaimsInterface
     const ADDRESS_CLAIM_VALUES  = 'formatted street_address locality region postal_code country';
     const PHONE_CLAIM_VALUES    = 'phone_number phone_number_verified';
 
-    const CLAIM_EMAIL_NUMBER_VERIFIED = 'email_verified';
+    const CLAIM_EMAIL_VERIFIED = 'email_verified';
     const CLAIM_PHONE_NUMBER_VERIFIED = 'phone_number_verified';
 
     /**

--- a/src/OAuth2/OpenID/Storage/UserClaimsInterface.php
+++ b/src/OAuth2/OpenID/Storage/UserClaimsInterface.php
@@ -9,7 +9,7 @@ namespace OAuth2\OpenID\Storage;
 interface UserClaimsInterface
 {
     // valid scope values to pass into the user claims API call
-    const VALID_SCOPE_VALUES = 'profile email address phone';
+    const VALID_CLAIMS = 'profile email address phone';
     const SCOPE_ADDRESS = 'address';
 
     // fields returned for the claims above

--- a/src/OAuth2/OpenID/Storage/UserClaimsInterface.php
+++ b/src/OAuth2/OpenID/Storage/UserClaimsInterface.php
@@ -9,13 +9,17 @@ namespace OAuth2\OpenID\Storage;
 interface UserClaimsInterface
 {
     // valid scope values to pass into the user claims API call
-    const VALID_CLAIMS = 'profile email address phone';
+    const VALID_SCOPE_VALUES = 'profile email address phone';
+    const SCOPE_ADDRESS = 'address';
 
     // fields returned for the claims above
     const PROFILE_CLAIM_VALUES  = 'name family_name given_name middle_name nickname preferred_username profile picture website gender birthdate zoneinfo locale updated_at';
     const EMAIL_CLAIM_VALUES    = 'email email_verified';
     const ADDRESS_CLAIM_VALUES  = 'formatted street_address locality region postal_code country';
     const PHONE_CLAIM_VALUES    = 'phone_number phone_number_verified';
+
+    const CLAIM_EMAIL_NUMBER_VERIFIED = 'email_verified';
+    const CLAIM_PHONE_NUMBER_VERIFIED = 'phone_number_verified';
 
     /**
      * Return claims about the provided user id.

--- a/src/OAuth2/Storage/Cassandra.php
+++ b/src/OAuth2/Storage/Cassandra.php
@@ -431,7 +431,7 @@ class Cassandra implements AuthorizationCodeInterface,
         }
 
         $userClaims = array();
-        $scopeValues = array_intersect(explode(' ', self::VALID_SCOPE_VALUES), explode(' ', $scope));
+        $scopeValues = array_intersect(explode(' ', self::VALID_CLAIMS), explode(' ', $scope));
         foreach ($scopeValues as $scopeValue) {
             $userClaims = array_merge($userClaims, $this->getUserClaim($scopeValue, $userDetails));
         }

--- a/src/OAuth2/Storage/Cassandra.php
+++ b/src/OAuth2/Storage/Cassandra.php
@@ -479,7 +479,7 @@ class Cassandra implements AuthorizationCodeInterface,
 
     protected static function parseBool($value)
     {
-        return ((is_bool($value) || is_numeric($value)) && (bool)$value) || (is_string($value) && !strcasecmp($value, 'true'));
+        return is_string($value) ? filter_var($value, FILTER_VALIDATE_BOOLEAN) : (bool)$value;
     }
 
 }

--- a/src/OAuth2/Storage/Cassandra.php
+++ b/src/OAuth2/Storage/Cassandra.php
@@ -465,8 +465,8 @@ class Cassandra implements AuthorizationCodeInterface,
         else {
             foreach ($claimValues as $claimValue) {
                 if (isset($userDetails[$claimValue])) {
-                    if (in_array($claimValue, array(self::CLAIM_EMAIL_NUMBER_VERIFIED, self::CLAIM_PHONE_NUMBER_VERIFIED), true)) {
-                        $userDetails[$claimValue] = (is_string($userDetails[$claimValue]) && !strcasecmp($userDetails[$claimValue], 'true')) || (!is_string($userDetails[$claimValue]) && (bool)$userDetails[$claimValue]);
+                    if (in_array($claimValue, array(self::CLAIM_EMAIL_VERIFIED, self::CLAIM_PHONE_NUMBER_VERIFIED), true)) {
+                        $userDetails[$claimValue] = (is_string($userDetails[$claimValue]) && !strcasecmp($userDetails[$claimValue], 'true')) || ((is_numeric($userDetails[$claimValue]) || is_bool($userDetails[$claimValue])) && (bool)$userDetails[$claimValue]);
                     }
 
                     $userClaims[$claimValue] = $userDetails[$claimValue];

--- a/src/OAuth2/Storage/Cassandra.php
+++ b/src/OAuth2/Storage/Cassandra.php
@@ -443,7 +443,7 @@ class Cassandra implements AuthorizationCodeInterface,
     {
         $userClaims = array();
         $claimValuesString = constant(sprintf('self::%s_CLAIM_VALUES', strtoupper($scopeValue)));
-        $claimValues = explode(' ', $claimValuesString);
+        $claimValues = explode(' ', $claimValuesString); // claims to get from user details
 
         if ($scopeValue === self::SCOPE_ADDRESS) {
             if (isset($userDetails[self::SCOPE_ADDRESS]) && is_array($userDetails[self::SCOPE_ADDRESS])) {
@@ -453,20 +453,20 @@ class Cassandra implements AuthorizationCodeInterface,
             $addressClaims = array();
 
             foreach ($claimValues as $claimValue) {
-                if (isset($userDetails[$claimValue])) {
+                if (isset($userDetails[$claimValue])) { // if claim exists in user details add it to address claim
                     $addressClaims[$claimValue] = $userDetails[$claimValue];
                 }
             }
 
-            if (count($addressClaims)) {
+            if (count($addressClaims)) { // if address claim not empty add it to return claims
                 $userClaims[self::SCOPE_ADDRESS] = $addressClaims;
             }
         }
         else {
             foreach ($claimValues as $claimValue) {
-                if (isset($userDetails[$claimValue])) {
+                if (isset($userDetails[$claimValue])) { // if claim exists in user details add it to return claims
                     if (in_array($claimValue, array(self::CLAIM_EMAIL_VERIFIED, self::CLAIM_PHONE_NUMBER_VERIFIED), true)) {
-                        $userDetails[$claimValue] = (is_string($userDetails[$claimValue]) && !strcasecmp($userDetails[$claimValue], 'true')) || ((is_numeric($userDetails[$claimValue]) || is_bool($userDetails[$claimValue])) && (bool)$userDetails[$claimValue]);
+                        $userDetails[$claimValue] = self::parseBool($userDetails[$claimValue]);
                     }
 
                     $userClaims[$claimValue] = $userDetails[$claimValue];
@@ -475,6 +475,11 @@ class Cassandra implements AuthorizationCodeInterface,
         }
 
         return $userClaims;
+    }
+
+    protected static function parseBool($value)
+    {
+        return ((is_bool($value) || is_numeric($value)) && (bool)$value) || (is_string($value) && !strcasecmp($value, 'true'));
     }
 
 }

--- a/src/OAuth2/Storage/Cassandra.php
+++ b/src/OAuth2/Storage/Cassandra.php
@@ -423,43 +423,54 @@ class Cassandra implements AuthorizationCodeInterface,
     }
 
     /* UserClaimsInterface */
-    public function getUserClaims($user_id, $claims)
+    public function getUserClaims($user_id, $scope)
     {
         $userDetails = $this->getUserDetails($user_id);
         if (!is_array($userDetails)) {
             return false;
         }
 
-        $claims = explode(' ', trim($claims));
         $userClaims = array();
-
-        // for each requested claim, if the user has the claim, set it in the response
-        $validClaims = explode(' ', self::VALID_CLAIMS);
-        foreach ($validClaims as $validClaim) {
-            if (in_array($validClaim, $claims)) {
-                if ($validClaim == 'address') {
-                    // address is an object with subfields
-                    $userClaims['address'] = $this->getUserClaim($validClaim, $userDetails['address'] ?: $userDetails);
-                } else {
-                    $userClaims = array_merge($userClaims, $this->getUserClaim($validClaim, $userDetails));
-                }
-            }
+        $scopeValues = array_intersect(explode(' ', self::VALID_SCOPE_VALUES), explode(' ', $scope));
+        foreach ($scopeValues as $scopeValue) {
+            $userClaims = array_merge($userClaims, $this->getUserClaim($scopeValue, $userDetails));
         }
 
         return $userClaims;
     }
 
-    protected function getUserClaim($claim, $userDetails)
+    protected function getUserClaim($scopeValue, $userDetails)
     {
         $userClaims = array();
-        $claimValuesString = constant(sprintf('self::%s_CLAIM_VALUES', strtoupper($claim)));
+        $claimValuesString = constant(sprintf('self::%s_CLAIM_VALUES', strtoupper($scopeValue)));
         $claimValues = explode(' ', $claimValuesString);
 
-        foreach ($claimValues as $value) {
-            if ($value == 'email_verified') {
-                $userClaims[$value] = $userDetails[$value]=='true' ? true : false;
-            } else {
-                $userClaims[$value] = isset($userDetails[$value]) ? $userDetails[$value] : null;
+        if ($scopeValue === self::SCOPE_ADDRESS) {
+            if (isset($userDetails[self::SCOPE_ADDRESS]) && is_array($userDetails[self::SCOPE_ADDRESS])) {
+                $userDetails = $userDetails[self::SCOPE_ADDRESS];
+            }
+
+            $addressClaims = array();
+
+            foreach ($claimValues as $claimValue) {
+                if (isset($userDetails[$claimValue])) {
+                    $addressClaims[$claimValue] = $userDetails[$claimValue];
+                }
+            }
+
+            if (count($addressClaims)) {
+                $userClaims[self::SCOPE_ADDRESS] = $addressClaims;
+            }
+        }
+        else {
+            foreach ($claimValues as $claimValue) {
+                if (isset($userDetails[$claimValue])) {
+                    if (in_array($claimValue, array(self::CLAIM_EMAIL_NUMBER_VERIFIED, self::CLAIM_PHONE_NUMBER_VERIFIED), true)) {
+                        $userDetails[$claimValue] = (is_string($userDetails[$claimValue]) && !strcasecmp($userDetails[$claimValue], 'true')) || (!is_string($userDetails[$claimValue]) && (bool)$userDetails[$claimValue]);
+                    }
+
+                    $userClaims[$claimValue] = $userDetails[$claimValue];
+                }
             }
         }
 

--- a/src/OAuth2/Storage/DynamoDB.php
+++ b/src/OAuth2/Storage/DynamoDB.php
@@ -275,7 +275,7 @@ class DynamoDB implements
     {
         $userClaims = array();
         $claimValuesString = constant(sprintf('self::%s_CLAIM_VALUES', strtoupper($scopeValue)));
-        $claimValues = explode(' ', $claimValuesString);
+        $claimValues = explode(' ', $claimValuesString); // claims to get from user details
 
         if ($scopeValue === self::SCOPE_ADDRESS) {
             if (isset($userDetails[self::SCOPE_ADDRESS]) && is_array($userDetails[self::SCOPE_ADDRESS])) {
@@ -285,20 +285,20 @@ class DynamoDB implements
             $addressClaims = array();
 
             foreach ($claimValues as $claimValue) {
-                if (isset($userDetails[$claimValue])) {
+                if (isset($userDetails[$claimValue])) { // if claim exists in user details add it to address claim
                     $addressClaims[$claimValue] = $userDetails[$claimValue];
                 }
             }
 
-            if (count($addressClaims)) {
+            if (count($addressClaims)) { // if address claim not empty add it to return claims
                 $userClaims[self::SCOPE_ADDRESS] = $addressClaims;
             }
         }
         else {
             foreach ($claimValues as $claimValue) {
-                if (isset($userDetails[$claimValue])) {
+                if (isset($userDetails[$claimValue])) { // if claim exists in user details add it to return claims
                     if (in_array($claimValue, array(self::CLAIM_EMAIL_VERIFIED, self::CLAIM_PHONE_NUMBER_VERIFIED), true)) {
-                        $userDetails[$claimValue] = (is_string($userDetails[$claimValue]) && !strcasecmp($userDetails[$claimValue], 'true')) || ((is_numeric($userDetails[$claimValue]) || is_bool($userDetails[$claimValue])) && (bool)$userDetails[$claimValue]);
+                        $userDetails[$claimValue] = self::parseBool($userDetails[$claimValue]);
                     }
 
                     $userClaims[$claimValue] = $userDetails[$claimValue];
@@ -307,6 +307,11 @@ class DynamoDB implements
         }
 
         return $userClaims;
+    }
+
+    protected static function parseBool($value)
+    {
+        return ((is_bool($value) || is_numeric($value)) && (bool)$value) || (is_string($value) && !strcasecmp($value, 'true'));
     }
 
     /* OAuth2\Storage\RefreshTokenInterface */

--- a/src/OAuth2/Storage/DynamoDB.php
+++ b/src/OAuth2/Storage/DynamoDB.php
@@ -311,7 +311,7 @@ class DynamoDB implements
 
     protected static function parseBool($value)
     {
-        return ((is_bool($value) || is_numeric($value)) && (bool)$value) || (is_string($value) && !strcasecmp($value, 'true'));
+        return is_string($value) ? filter_var($value, FILTER_VALIDATE_BOOLEAN) : (bool)$value;
     }
 
     /* OAuth2\Storage\RefreshTokenInterface */

--- a/src/OAuth2/Storage/DynamoDB.php
+++ b/src/OAuth2/Storage/DynamoDB.php
@@ -297,8 +297,8 @@ class DynamoDB implements
         else {
             foreach ($claimValues as $claimValue) {
                 if (isset($userDetails[$claimValue])) {
-                    if (in_array($claimValue, array(self::CLAIM_EMAIL_NUMBER_VERIFIED, self::CLAIM_PHONE_NUMBER_VERIFIED), true)) {
-                        $userDetails[$claimValue] = (is_string($userDetails[$claimValue]) && !strcasecmp($userDetails[$claimValue], 'true')) || (!is_string($userDetails[$claimValue]) && (bool)$userDetails[$claimValue]);
+                    if (in_array($claimValue, array(self::CLAIM_EMAIL_VERIFIED, self::CLAIM_PHONE_NUMBER_VERIFIED), true)) {
+                        $userDetails[$claimValue] = (is_string($userDetails[$claimValue]) && !strcasecmp($userDetails[$claimValue], 'true')) || ((is_numeric($userDetails[$claimValue]) || is_bool($userDetails[$claimValue])) && (bool)$userDetails[$claimValue]);
                     }
 
                     $userClaims[$claimValue] = $userDetails[$claimValue];

--- a/src/OAuth2/Storage/DynamoDB.php
+++ b/src/OAuth2/Storage/DynamoDB.php
@@ -263,7 +263,7 @@ class DynamoDB implements
         }
 
         $userClaims = array();
-        $scopeValues = array_intersect(explode(' ', self::VALID_SCOPE_VALUES), explode(' ', $scope));
+        $scopeValues = array_intersect(explode(' ', self::VALID_CLAIMS), explode(' ', $scope));
         foreach ($scopeValues as $scopeValue) {
             $userClaims = array_merge($userClaims, $this->getUserClaim($scopeValue, $userDetails));
         }

--- a/src/OAuth2/Storage/Memory.php
+++ b/src/OAuth2/Storage/Memory.php
@@ -145,7 +145,7 @@ class Memory implements AuthorizationCodeInterface,
     {
         $userClaims = array();
         $claimValuesString = constant(sprintf('self::%s_CLAIM_VALUES', strtoupper($scopeValue)));
-        $claimValues = explode(' ', $claimValuesString);
+        $claimValues = explode(' ', $claimValuesString); // claims to get from user details
 
         if ($scopeValue === self::SCOPE_ADDRESS) {
             if (isset($userDetails[self::SCOPE_ADDRESS]) && is_array($userDetails[self::SCOPE_ADDRESS])) {
@@ -155,20 +155,20 @@ class Memory implements AuthorizationCodeInterface,
             $addressClaims = array();
 
             foreach ($claimValues as $claimValue) {
-                if (isset($userDetails[$claimValue])) {
+                if (isset($userDetails[$claimValue])) { // if claim exists in user details add it to address claim
                     $addressClaims[$claimValue] = $userDetails[$claimValue];
                 }
             }
 
-            if (count($addressClaims)) {
+            if (count($addressClaims)) { // if address claim not empty add it to return claims
                 $userClaims[self::SCOPE_ADDRESS] = $addressClaims;
             }
         }
         else {
             foreach ($claimValues as $claimValue) {
-                if (isset($userDetails[$claimValue])) {
+                if (isset($userDetails[$claimValue])) { // if claim exists in user details add it to return claims
                     if (in_array($claimValue, array(self::CLAIM_EMAIL_VERIFIED, self::CLAIM_PHONE_NUMBER_VERIFIED), true)) {
-                        $userDetails[$claimValue] = (is_string($userDetails[$claimValue]) && !strcasecmp($userDetails[$claimValue], 'true')) || ((is_numeric($userDetails[$claimValue]) || is_bool($userDetails[$claimValue])) && (bool)$userDetails[$claimValue]);
+                        $userDetails[$claimValue] = self::parseBool($userDetails[$claimValue]);
                     }
 
                     $userClaims[$claimValue] = $userDetails[$claimValue];
@@ -177,6 +177,11 @@ class Memory implements AuthorizationCodeInterface,
         }
 
         return $userClaims;
+    }
+
+    protected static function parseBool($value)
+    {
+        return ((is_bool($value) || is_numeric($value)) && (bool)$value) || (is_string($value) && !strcasecmp($value, 'true'));
     }
 
     /* ClientCredentialsInterface */

--- a/src/OAuth2/Storage/Memory.php
+++ b/src/OAuth2/Storage/Memory.php
@@ -133,7 +133,7 @@ class Memory implements AuthorizationCodeInterface,
         }
 
         $userClaims = array();
-        $scopeValues = array_intersect(explode(' ', self::VALID_SCOPE_VALUES), explode(' ', $scope));
+        $scopeValues = array_intersect(explode(' ', self::VALID_CLAIMS), explode(' ', $scope));
         foreach ($scopeValues as $scopeValue) {
             $userClaims = array_merge($userClaims, $this->getUserClaim($scopeValue, $userDetails));
         }

--- a/src/OAuth2/Storage/Memory.php
+++ b/src/OAuth2/Storage/Memory.php
@@ -125,39 +125,55 @@ class Memory implements AuthorizationCodeInterface,
     }
 
     /* UserClaimsInterface */
-    public function getUserClaims($user_id, $claims)
+    public function getUserClaims($user_id, $scope)
     {
-        if (!$userDetails = $this->getUserDetails($user_id)) {
+        $userDetails = $this->getUserDetails($user_id);
+        if (!is_array($userDetails)) {
             return false;
         }
 
-        $claims = explode(' ', trim($claims));
         $userClaims = array();
-
-        // for each requested claim, if the user has the claim, set it in the response
-        $validClaims = explode(' ', self::VALID_CLAIMS);
-        foreach ($validClaims as $validClaim) {
-            if (in_array($validClaim, $claims)) {
-                if ($validClaim == 'address') {
-                    // address is an object with subfields
-                    $userClaims['address'] = $this->getUserClaim($validClaim, $userDetails['address'] ?: $userDetails);
-                } else {
-                    $userClaims = array_merge($this->getUserClaim($validClaim, $userDetails));
-                }
-            }
+        $scopeValues = array_intersect(explode(' ', self::VALID_SCOPE_VALUES), explode(' ', $scope));
+        foreach ($scopeValues as $scopeValue) {
+            $userClaims = array_merge($userClaims, $this->getUserClaim($scopeValue, $userDetails));
         }
 
         return $userClaims;
     }
 
-    protected function getUserClaim($claim, $userDetails)
+    protected function getUserClaim($scopeValue, $userDetails)
     {
         $userClaims = array();
-        $claimValuesString = constant(sprintf('self::%s_CLAIM_VALUES', strtoupper($claim)));
+        $claimValuesString = constant(sprintf('self::%s_CLAIM_VALUES', strtoupper($scopeValue)));
         $claimValues = explode(' ', $claimValuesString);
 
-        foreach ($claimValues as $value) {
-            $userClaims[$value] = isset($userDetails[$value]) ? $userDetails[$value] : null;
+        if ($scopeValue === self::SCOPE_ADDRESS) {
+            if (isset($userDetails[self::SCOPE_ADDRESS]) && is_array($userDetails[self::SCOPE_ADDRESS])) {
+                $userDetails = $userDetails[self::SCOPE_ADDRESS];
+            }
+
+            $addressClaims = array();
+
+            foreach ($claimValues as $claimValue) {
+                if (isset($userDetails[$claimValue])) {
+                    $addressClaims[$claimValue] = $userDetails[$claimValue];
+                }
+            }
+
+            if (count($addressClaims)) {
+                $userClaims[self::SCOPE_ADDRESS] = $addressClaims;
+            }
+        }
+        else {
+            foreach ($claimValues as $claimValue) {
+                if (isset($userDetails[$claimValue])) {
+                    if (in_array($claimValue, array(self::CLAIM_EMAIL_NUMBER_VERIFIED, self::CLAIM_PHONE_NUMBER_VERIFIED), true)) {
+                        $userDetails[$claimValue] = (is_string($userDetails[$claimValue]) && !strcasecmp($userDetails[$claimValue], 'true')) || (!is_string($userDetails[$claimValue]) && (bool)$userDetails[$claimValue]);
+                    }
+
+                    $userClaims[$claimValue] = $userDetails[$claimValue];
+                }
+            }
         }
 
         return $userClaims;

--- a/src/OAuth2/Storage/Memory.php
+++ b/src/OAuth2/Storage/Memory.php
@@ -181,7 +181,7 @@ class Memory implements AuthorizationCodeInterface,
 
     protected static function parseBool($value)
     {
-        return ((is_bool($value) || is_numeric($value)) && (bool)$value) || (is_string($value) && !strcasecmp($value, 'true'));
+        return is_string($value) ? filter_var($value, FILTER_VALIDATE_BOOLEAN) : (bool)$value;
     }
 
     /* ClientCredentialsInterface */

--- a/src/OAuth2/Storage/Memory.php
+++ b/src/OAuth2/Storage/Memory.php
@@ -167,8 +167,8 @@ class Memory implements AuthorizationCodeInterface,
         else {
             foreach ($claimValues as $claimValue) {
                 if (isset($userDetails[$claimValue])) {
-                    if (in_array($claimValue, array(self::CLAIM_EMAIL_NUMBER_VERIFIED, self::CLAIM_PHONE_NUMBER_VERIFIED), true)) {
-                        $userDetails[$claimValue] = (is_string($userDetails[$claimValue]) && !strcasecmp($userDetails[$claimValue], 'true')) || (!is_string($userDetails[$claimValue]) && (bool)$userDetails[$claimValue]);
+                    if (in_array($claimValue, array(self::CLAIM_EMAIL_VERIFIED, self::CLAIM_PHONE_NUMBER_VERIFIED), true)) {
+                        $userDetails[$claimValue] = (is_string($userDetails[$claimValue]) && !strcasecmp($userDetails[$claimValue], 'true')) || ((is_numeric($userDetails[$claimValue]) || is_bool($userDetails[$claimValue])) && (bool)$userDetails[$claimValue]);
                     }
 
                     $userClaims[$claimValue] = $userDetails[$claimValue];

--- a/src/OAuth2/Storage/Pdo.php
+++ b/src/OAuth2/Storage/Pdo.php
@@ -235,39 +235,55 @@ class Pdo implements
     }
 
     /* UserClaimsInterface */
-    public function getUserClaims($user_id, $claims)
+    public function getUserClaims($user_id, $scope)
     {
-        if (!$userDetails = $this->getUserDetails($user_id)) {
+        $userDetails = $this->getUserDetails($user_id);
+        if (!is_array($userDetails)) {
             return false;
         }
 
-        $claims = explode(' ', trim($claims));
         $userClaims = array();
-
-        // for each requested claim, if the user has the claim, set it in the response
-        $validClaims = explode(' ', self::VALID_CLAIMS);
-        foreach ($validClaims as $validClaim) {
-            if (in_array($validClaim, $claims)) {
-                if ($validClaim == 'address') {
-                    // address is an object with subfields
-                    $userClaims['address'] = $this->getUserClaim($validClaim, $userDetails['address'] ?: $userDetails);
-                } else {
-                    $userClaims = array_merge($userClaims, $this->getUserClaim($validClaim, $userDetails));
-                }
-            }
+        $scopeValues = array_intersect(explode(' ', self::VALID_SCOPE_VALUES), explode(' ', $scope));
+        foreach ($scopeValues as $scopeValue) {
+            $userClaims = array_merge($userClaims, $this->getUserClaim($scopeValue, $userDetails));
         }
 
         return $userClaims;
     }
 
-    protected function getUserClaim($claim, $userDetails)
+    protected function getUserClaim($scopeValue, $userDetails)
     {
         $userClaims = array();
-        $claimValuesString = constant(sprintf('self::%s_CLAIM_VALUES', strtoupper($claim)));
+        $claimValuesString = constant(sprintf('self::%s_CLAIM_VALUES', strtoupper($scopeValue)));
         $claimValues = explode(' ', $claimValuesString);
 
-        foreach ($claimValues as $value) {
-            $userClaims[$value] = isset($userDetails[$value]) ? $userDetails[$value] : null;
+        if ($scopeValue === self::SCOPE_ADDRESS) {
+            if (isset($userDetails[self::SCOPE_ADDRESS]) && is_array($userDetails[self::SCOPE_ADDRESS])) {
+                $userDetails = $userDetails[self::SCOPE_ADDRESS];
+            }
+
+            $addressClaims = array();
+
+            foreach ($claimValues as $claimValue) {
+                if (isset($userDetails[$claimValue])) {
+                    $addressClaims[$claimValue] = $userDetails[$claimValue];
+                }
+            }
+
+            if (count($addressClaims)) {
+                $userClaims[self::SCOPE_ADDRESS] = $addressClaims;
+            }
+        }
+        else {
+            foreach ($claimValues as $claimValue) {
+                if (isset($userDetails[$claimValue])) {
+                    if (in_array($claimValue, array(self::CLAIM_EMAIL_NUMBER_VERIFIED, self::CLAIM_PHONE_NUMBER_VERIFIED), true)) {
+                        $userDetails[$claimValue] = (is_string($userDetails[$claimValue]) && !strcasecmp($userDetails[$claimValue], 'true')) || (!is_string($userDetails[$claimValue]) && (bool)$userDetails[$claimValue]);
+                    }
+
+                    $userClaims[$claimValue] = $userDetails[$claimValue];
+                }
+            }
         }
 
         return $userClaims;

--- a/src/OAuth2/Storage/Pdo.php
+++ b/src/OAuth2/Storage/Pdo.php
@@ -291,7 +291,7 @@ class Pdo implements
 
     protected static function parseBool($value)
     {
-        return ((is_bool($value) || is_numeric($value)) && (bool)$value) || (is_string($value) && !strcasecmp($value, 'true'));
+        return is_string($value) ? filter_var($value, FILTER_VALIDATE_BOOLEAN) : (bool)$value;
     }
 
     /* OAuth2\Storage\RefreshTokenInterface */

--- a/src/OAuth2/Storage/Pdo.php
+++ b/src/OAuth2/Storage/Pdo.php
@@ -243,7 +243,7 @@ class Pdo implements
         }
 
         $userClaims = array();
-        $scopeValues = array_intersect(explode(' ', self::VALID_SCOPE_VALUES), explode(' ', $scope));
+        $scopeValues = array_intersect(explode(' ', self::VALID_CLAIMS), explode(' ', $scope));
         foreach ($scopeValues as $scopeValue) {
             $userClaims = array_merge($userClaims, $this->getUserClaim($scopeValue, $userDetails));
         }

--- a/src/OAuth2/Storage/Pdo.php
+++ b/src/OAuth2/Storage/Pdo.php
@@ -277,8 +277,8 @@ class Pdo implements
         else {
             foreach ($claimValues as $claimValue) {
                 if (isset($userDetails[$claimValue])) {
-                    if (in_array($claimValue, array(self::CLAIM_EMAIL_NUMBER_VERIFIED, self::CLAIM_PHONE_NUMBER_VERIFIED), true)) {
-                        $userDetails[$claimValue] = (is_string($userDetails[$claimValue]) && !strcasecmp($userDetails[$claimValue], 'true')) || (!is_string($userDetails[$claimValue]) && (bool)$userDetails[$claimValue]);
+                    if (in_array($claimValue, array(self::CLAIM_EMAIL_VERIFIED, self::CLAIM_PHONE_NUMBER_VERIFIED), true)) {
+                        $userDetails[$claimValue] = (is_string($userDetails[$claimValue]) && !strcasecmp($userDetails[$claimValue], 'true')) || ((is_numeric($userDetails[$claimValue]) || is_bool($userDetails[$claimValue])) && (bool)$userDetails[$claimValue]);
                     }
 
                     $userClaims[$claimValue] = $userDetails[$claimValue];

--- a/src/OAuth2/Storage/Pdo.php
+++ b/src/OAuth2/Storage/Pdo.php
@@ -255,7 +255,7 @@ class Pdo implements
     {
         $userClaims = array();
         $claimValuesString = constant(sprintf('self::%s_CLAIM_VALUES', strtoupper($scopeValue)));
-        $claimValues = explode(' ', $claimValuesString);
+        $claimValues = explode(' ', $claimValuesString); // claims to get from user details
 
         if ($scopeValue === self::SCOPE_ADDRESS) {
             if (isset($userDetails[self::SCOPE_ADDRESS]) && is_array($userDetails[self::SCOPE_ADDRESS])) {
@@ -265,20 +265,20 @@ class Pdo implements
             $addressClaims = array();
 
             foreach ($claimValues as $claimValue) {
-                if (isset($userDetails[$claimValue])) {
+                if (isset($userDetails[$claimValue])) { // if claim exists in user details add it to address claim
                     $addressClaims[$claimValue] = $userDetails[$claimValue];
                 }
             }
 
-            if (count($addressClaims)) {
+            if (count($addressClaims)) { // if address claim not empty add it to return claims
                 $userClaims[self::SCOPE_ADDRESS] = $addressClaims;
             }
         }
         else {
             foreach ($claimValues as $claimValue) {
-                if (isset($userDetails[$claimValue])) {
+                if (isset($userDetails[$claimValue])) { // if claim exists in user details add it to return claims
                     if (in_array($claimValue, array(self::CLAIM_EMAIL_VERIFIED, self::CLAIM_PHONE_NUMBER_VERIFIED), true)) {
-                        $userDetails[$claimValue] = (is_string($userDetails[$claimValue]) && !strcasecmp($userDetails[$claimValue], 'true')) || ((is_numeric($userDetails[$claimValue]) || is_bool($userDetails[$claimValue])) && (bool)$userDetails[$claimValue]);
+                        $userDetails[$claimValue] = self::parseBool($userDetails[$claimValue]);
                     }
 
                     $userClaims[$claimValue] = $userDetails[$claimValue];
@@ -287,6 +287,11 @@ class Pdo implements
         }
 
         return $userClaims;
+    }
+
+    protected static function parseBool($value)
+    {
+        return ((is_bool($value) || is_numeric($value)) && (bool)$value) || (is_string($value) && !strcasecmp($value, 'true'));
     }
 
     /* OAuth2\Storage\RefreshTokenInterface */


### PR DESCRIPTION
According to [5.3.2. Successful UserInfo Response](http://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse)
If a Claim is not returned, that Claim Name SHOULD be omitted from the JSON object representing the Claims; it SHOULD NOT be present with a null or empty string value.

However, I believe that returning empty string is OK.
What do you think?
