### PR TITLE
Implemented method to override the password hashing algorithm

### DIFF
--- a/src/OAuth2/Storage/Cassandra.php
+++ b/src/OAuth2/Storage/Cassandra.php
@@ -182,7 +182,13 @@ class Cassandra implements AuthorizationCodeInterface,
     // plaintext passwords are bad!  Override this for your application
     protected function checkPassword($user, $password)
     {
-        return $user['password'] == sha1($password);
+        return $user['password'] == $this->hashPassword($password);
+    }
+
+    // use a secure hashing algorithm when storing passwords. Override this for your application
+    protected function hashPassword($password)
+    {
+        return sha1($password);
     }
 
     public function getUserDetails($username)
@@ -204,7 +210,7 @@ class Cassandra implements AuthorizationCodeInterface,
 
     public function setUser($username, $password, $first_name = null, $last_name = null)
     {
-        $password = sha1($password);
+        $password = $this->hashPassword($password);
 
         return $this->setValue(
             $this->config['user_key'] . $username,

--- a/src/OAuth2/Storage/DynamoDB.php
+++ b/src/OAuth2/Storage/DynamoDB.php
@@ -342,7 +342,13 @@ class DynamoDB implements
     // plaintext passwords are bad!  Override this for your application
     protected function checkPassword($user, $password)
     {
-        return $user['password'] == sha1($password);
+        return $user['password'] == $this->hashPassword($password);
+    }
+
+    // use a secure hashing algorithm when storing passwords. Override this for your application
+    protected function hashPassword($password)
+    {
+        return sha1($password);
     }
 
     public function getUser($username)
@@ -363,7 +369,7 @@ class DynamoDB implements
     public function setUser($username, $password, $first_name = null, $last_name = null)
     {
         // do not store in plaintext
-        $password = sha1($password);
+        $password = $this->hashPassword($password);
 
         $clientData = compact('username', 'password', 'first_name', 'last_name');
         $clientData = array_filter($clientData, 'self::isNotEmpty');

--- a/src/OAuth2/Storage/Pdo.php
+++ b/src/OAuth2/Storage/Pdo.php
@@ -307,7 +307,13 @@ class Pdo implements
     // plaintext passwords are bad!  Override this for your application
     protected function checkPassword($user, $password)
     {
-        return $user['password'] == sha1($password);
+        return $user['password'] == $this->hashPassword($password);
+    }
+
+    // use a secure hashing algorithm when storing passwords. Override this for your application
+    protected function hashPassword($password)
+    {
+        return sha1($password);
     }
 
     public function getUser($username)
@@ -328,7 +334,7 @@ class Pdo implements
     public function setUser($username, $password, $firstName = null, $lastName = null)
     {
         // do not store in plaintext
-        $password = sha1($password);
+        $password = $this->hashPassword($password);
 
         // if it exists, update it.
         if ($this->getUser($username)) {


### PR DESCRIPTION
By having `sha1($password)` hard-coded in the storage classes, it lacks flexibility for users who want to select a different password hashing algorithm. 
I encapsulated the hashing algorithm in an overridable method `hashPassword()`.