### PR TITLE
Fixing minor typo in Implicit grant type test

### DIFF
--- a/test/OAuth2/GrantType/ImplicitTest.php
+++ b/test/OAuth2/GrantType/ImplicitTest.php
@@ -125,7 +125,7 @@ class ImplicitTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('fragment', $parts);
         parse_str($parts['fragment'], $params);
 
-        $this->assertFalse(isset($parmas['fake']));
+        $this->assertFalse(isset($params['fake']));
         $this->assertArrayHasKey('state', $params);
         $this->assertEquals($params['state'], 'test');
     }


### PR DESCRIPTION
Funny enough, this is on testing the non-existence, so the assert will never fail.