### PR TITLE
Change PDO.php

### DIFF
--- a/src/OAuth2/Storage/Pdo.php
+++ b/src/OAuth2/Storage/Pdo.php
@@ -363,18 +363,31 @@ class Pdo implements
 
     public function getDefaultScope($client_id = null)
     {
-        $stmt = $this->db->prepare(sprintf('SELECT scope FROM %s WHERE is_default=:is_default', $this->config['scope_table']));
-        $stmt->execute(array('is_default' => true));
+        $getGlobalDefaults = true;
+        $defaultScopes = array();
 
-        if ($result = $stmt->fetchAll(\PDO::FETCH_ASSOC)) {
-            $defaultScope = array_map(function ($row) {
-                return $row['scope'];
-            }, $result);
-
-            return implode(' ', $defaultScope);
+        if (!is_null($client_id)) {
+            // Get (default) scopes from client table
+            $clientScope = $this->getClientScope($client_id);
+            if (!is_null($clientScope)) {
+                $getGlobalDefaults = false;
+                $defaultScopes = explode(' ', trim($clientScope));
+            }
         }
 
-        return null;
+        if ($getGlobalDefaults) {
+            // Get default scopes
+            $stmt = $this->db->prepare(sprintf('SELECT scope FROM %s WHERE is_default=:is_default', $this->config['scope_table']));
+            $stmt->execute(array('is_default' => true));
+
+            if ($result = $stmt->fetchAll(\PDO::FETCH_ASSOC)) {
+                $defaultScopes = array_map(function ($row) {
+                    return $row['scope'];
+                }, $result);
+            }
+        }
+        
+        return ( (!empty($defaultScopes)) ? implode(' ', $defaultScopes) : null );
     }
 
     /* JWTBearerInterface */


### PR DESCRIPTION
When getting the default scope from the database using PDO, the function neglects the $client_id provided instead of returning the client's scope from the client table. So I added that using the getClientScope function.
So now it return either default scopes set to client from client table or returns global default scopes from scope table.

I'm not sure if this should also be changed in other storage classes.