### PR TITLE
Token grant issue

### DIFF
--- a/src/OAuth2/Controller/TokenController.php
+++ b/src/OAuth2/Controller/TokenController.php
@@ -179,6 +179,10 @@ class TokenController implements TokenControllerInterface
                     $response->setError(400, 'invalid_scope', 'An unsupported scope was requested');
 
                     return null;
+                } else {
+                    $response->setError(400, 'invalid_scope', 'The scope requested is invalid for this client');
+
+                    return false;
                 }
             }
         } elseif ($availableScope) {


### PR DESCRIPTION
In the event a client has no scope yet a valid scope is requested I found the access_token is granted.  Added an `} else {` to catch this.

https://github.com/bshaffer/oauth2-server-php/blob/develop/src/OAuth2/Controller/TokenController.php#L175-L186