### PR TITLE
Memory Storage Fix - Add missing array_merge() parameter

### DIFF
--- a/src/OAuth2/Storage/Memory.php
+++ b/src/OAuth2/Storage/Memory.php
@@ -142,7 +142,7 @@ class Memory implements AuthorizationCodeInterface,
                     // address is an object with subfields
                     $userClaims['address'] = $this->getUserClaim($validClaim, $userDetails['address'] ?: $userDetails);
                 } else {
-                    $userClaims = array_merge($this->getUserClaim($validClaim, $userDetails));
+                    $userClaims = array_merge($userClaims, $this->getUserClaim($validClaim, $userDetails));
                 }
             }
         }


### PR DESCRIPTION
Hi @bshaffer,

Just a one-liner fix for a bug I stumbled on today.  I checked the other storages and Memory was the only one with the bug.

Cheers.