### PR TITLE
Update CodeIdToken.php

### DIFF
--- a/src/OAuth2/OpenID/ResponseType/CodeIdToken.php
+++ b/src/OAuth2/OpenID/ResponseType/CodeIdToken.php
@@ -16,8 +16,8 @@ class CodeIdToken implements CodeIdTokenInterface
     public function getAuthorizeResponse($params, $user_id = null)
     {
         $result = $this->authCode->getAuthorizeResponse($params, $user_id);
-        $id_token = $this->idToken->createIdToken($params['client_id'], $user_id, $params['nonce']);
-        $result[1]['query']['id_token'] = $id_token;
+        $resultIdToken = $this->idToken->getAuthorizeResponse($params, $user_id);
+        $result[1]['query']['id_token'] = $resultIdToken[1]['fragment']['id_token'];
 
         return $result;
     }

--- a/test/OAuth2/OpenID/ResponseType/CodeIdTokenTest.php
+++ b/test/OAuth2/OpenID/ResponseType/CodeIdTokenTest.php
@@ -67,6 +67,96 @@ class CodeIdTokenTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($duration, 3600);
     }
 
+    public function testUserClaimsWithUserId()
+    {
+        // add the test parameters in memory
+        $server = $this->getTestServer();
+
+        $request = new Request(array(
+            'response_type' => 'code id_token',
+            'redirect_uri'  => 'http://adobe.com',
+            'client_id'     => 'Test Client ID',
+            'scope'         => 'openid email',
+            'state'         => 'test',
+            'nonce'         => 'test',
+        ));
+
+        $userId = 'testuser';
+        $server->handleAuthorizeRequest($request, $response = new Response(), true, $userId);
+
+        $this->assertEquals($response->getStatusCode(), 302);
+        $location = $response->getHttpHeader('Location');
+        $this->assertNotContains('error', $location);
+
+        $parts = parse_url($location);
+        $this->assertArrayHasKey('query', $parts);
+
+        // assert fragment is in "application/x-www-form-urlencoded" format
+        parse_str($parts['query'], $params);
+        $this->assertNotNull($params);
+        $this->assertArrayHasKey('id_token', $params);
+        $this->assertArrayHasKey('code', $params);
+
+        // validate ID Token
+        $parts = explode('.', $params['id_token']);
+        foreach ($parts as &$part) {
+            // Each part is a base64url encoded json string.
+            $part = str_replace(array('-', '_'), array('+', '/'), $part);
+            $part = base64_decode($part);
+            $part = json_decode($part, true);
+        }
+        list($header, $claims, $signature) = $parts;
+
+        $this->assertArrayHasKey('email', $claims);
+        $this->assertArrayHasKey('email_verified', $claims);
+        $this->assertNotNull($claims['email']);
+        $this->assertNotNull($claims['email_verified']);
+    }
+
+    public function testUserClaimsWithoutUserId()
+    {
+        // add the test parameters in memory
+        $server = $this->getTestServer();
+
+        $request = new Request(array(
+            'response_type' => 'code id_token',
+            'redirect_uri'  => 'http://adobe.com',
+            'client_id'     => 'Test Client ID',
+            'scope'         => 'openid email',
+            'state'         => 'test',
+            'nonce'         => 'test',
+        ));
+
+        $userId = null;
+        $server->handleAuthorizeRequest($request, $response = new Response(), true, $userId);
+
+        $this->assertEquals($response->getStatusCode(), 302);
+        $location = $response->getHttpHeader('Location');
+        $this->assertNotContains('error', $location);
+
+        $parts = parse_url($location);
+        $this->assertArrayHasKey('query', $parts);
+
+        // assert fragment is in "application/x-www-form-urlencoded" format
+        parse_str($parts['query'], $params);
+        $this->assertNotNull($params);
+        $this->assertArrayHasKey('id_token', $params);
+        $this->assertArrayHasKey('code', $params);
+
+        // validate ID Token
+        $parts = explode('.', $params['id_token']);
+        foreach ($parts as &$part) {
+            // Each part is a base64url encoded json string.
+            $part = str_replace(array('-', '_'), array('+', '/'), $part);
+            $part = base64_decode($part);
+            $part = json_decode($part, true);
+        }
+        list($header, $claims, $signature) = $parts;
+
+        $this->assertArrayNotHasKey('email', $claims);
+        $this->assertArrayNotHasKey('email_verified', $claims);
+    }
+
     private function getTestServer($config = array())
     {
         $config += array(
@@ -77,6 +167,7 @@ class CodeIdTokenTest extends \PHPUnit_Framework_TestCase
         );
 
         $memoryStorage = Bootstrap::getInstance()->getMemoryStorage();
+        $memoryStorage->supportedScopes[] = 'email';
         $responseTypes = array(
             'code'     => $code    = new AuthorizationCode($memoryStorage),
             'id_token' => $idToken = new IdToken($memoryStorage, $memoryStorage, $config),


### PR DESCRIPTION
If response_type == "code id_token" fix id_token for support Claims.
Remove dereferencing for support PHP 5.3

adds tests for #737