### PR TITLE
Fix "redirect_uri_mismatch" for URIs with encoded characters

### DIFF
--- a/src/OAuth2/GrantType/AuthorizationCode.php
+++ b/src/OAuth2/GrantType/AuthorizationCode.php
@@ -49,7 +49,7 @@ class AuthorizationCode implements GrantTypeInterface
          * @uri - http://tools.ietf.org/html/rfc6749#section-4.1.3
          */
         if (isset($authCode['redirect_uri']) && $authCode['redirect_uri']) {
-            if (!$request->request('redirect_uri') || urldecode($request->request('redirect_uri')) != $authCode['redirect_uri']) {
+            if (!$request->request('redirect_uri') || urldecode($request->request('redirect_uri')) != urldecode($authCode['redirect_uri'])) {
                 $response->setError(400, 'redirect_uri_mismatch', "The redirect URI is missing or do not match", "#section-4.1.3");
 
                 return false;

--- a/test/OAuth2/GrantType/AuthorizationCodeTest.php
+++ b/test/OAuth2/GrantType/AuthorizationCodeTest.php
@@ -93,6 +93,22 @@ class AuthorizationCodeTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('access_token', $token);
     }
 
+    public function testValidRedirectUri()
+    {
+        $server = $this->getTestServer();
+        $request = TestRequest::createPost(array(
+            'grant_type'    => 'authorization_code', // valid grant type
+            'client_id'     => 'Test Client ID', // valid client id
+            'redirect_uri'  => 'http://brentertainment.com/voil%C3%A0', // valid client id
+            'client_secret' => 'TestSecret', // valid client secret
+            'code'          => 'testcode-redirect-uri', // valid code
+        ));
+        $token = $server->grantAccessToken($request, new Response());
+
+        $this->assertNotNull($token);
+        $this->assertArrayHasKey('access_token', $token);
+    }
+
     public function testValidCodeNoScope()
     {
         $server = $this->getTestServer();

--- a/test/config/storage.json
+++ b/test/config/storage.json
@@ -32,6 +32,13 @@
             "redirect_uri": "",
             "expires": "9999999999",
             "id_token": "test_id_token"
+        },
+        "testcode-redirect-uri": {
+            "client_id": "Test Client ID",
+            "user_id": "",
+            "redirect_uri": "http://brentertainment.com/voil%C3%A0",
+            "expires": "9999999999",
+            "id_token": "IDTOKEN"
         }
     },
     "client_credentials" : {


### PR DESCRIPTION
redirect_uri are not urlencoded before being stored, so if we want to compare the "canonical" (decoded) URIs, we need to decode both
