### PR TITLE
Add .gitattributes files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Exclude unused files
+# see: https://redd.it/2jzp6k
+/tests                     export-ignore
+.travis.yml                export-ignore
+.gitattributes             export-ignore
+.gitignore                 export-ignore
+phpunit.xml                export-ignore


### PR DESCRIPTION
The .gitattributes file will prevent items such as test files, yaml files, etc from being included when this library is imported via composer