### PR TITLE
RFC6750 compatibility

### DIFF
--- a/src/OAuth2/Controller/ResourceController.php
+++ b/src/OAuth2/Controller/ResourceController.php
@@ -83,7 +83,7 @@ class ResourceController implements ResourceControllerInterface
             } elseif (!isset($token["expires"]) || !isset($token["client_id"])) {
                 $response->setError(401, 'malformed_token', 'Malformed token (missing "expires")');
             } elseif (time() > $token["expires"]) {
-                $response->setError(401, 'expired_token', 'The access token provided has expired');
+                $response->setError(401, 'invalid_token', 'The access token provided has expired');
             } else {
                 return $token;
             }

--- a/test/OAuth2/Controller/ResourceControllerTest.php
+++ b/test/OAuth2/Controller/ResourceControllerTest.php
@@ -100,7 +100,7 @@ class ResourceControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($allow);
 
         $this->assertEquals($response->getStatusCode(), 401);
-        $this->assertEquals($response->getParameter('error'), 'expired_token');
+        $this->assertEquals($response->getParameter('error'), 'invalid_token');
         $this->assertEquals($response->getParameter('error_description'), 'The access token provided has expired');
     }
 


### PR DESCRIPTION
Changing from 'expired_token' to 'invalid_token' to be compatible with http://tools.ietf.org/html/rfc6750#section-6.2.2