### PR TITLE
added easier method to customize jwt token payload

### DIFF
--- a/src/OAuth2/ResponseType/JwtAccessToken.php
+++ b/src/OAuth2/ResponseType/JwtAccessToken.php
@@ -60,7 +60,7 @@ class JwtAccessToken extends AccessToken
     public function createAccessToken($client_id, $user_id, $scope = null, $includeRefreshToken = true)
     {
         // payload to encrypt
-        $payload = $this->generatePayload($client_id, $user_id, $scope);
+        $payload = $this->createPayload($client_id, $user_id, $scope);
 
         /*
          * Encode the payload data into a single JWT access_token string
@@ -110,7 +110,7 @@ class JwtAccessToken extends AccessToken
         return $this->encryptionUtil->encode($token, $private_key, $algorithm);
     }
 
-    protected function generatePayload($client_id, $user_id, $scope = null)
+    protected function createPayload($client_id, $user_id, $scope = null)
     {
         // token to encrypt
         $expires = time() + $this->config['access_lifetime'];


### PR DESCRIPTION
as suggested in https://github.com/bshaffer/oauth2-server-php/issues/793 
@bshaffer is it something like this?

 usage example:
```php

class MyJwtToken extends \OAuth2\ResponseType\JwtAccessToken
{
    protected function createPayload($client_id, $user_id, $scope = null)
    {
        $payload = parent::createPayload($client_id, $user_id, $scope);
        $payload['custom_param'] = 'my important value';

        return $payload;
    }
}


$server = new OAuth2\Server($storage, $config);

$jwtTokenResponseType = new MyJwtToken($publicKeyStorage, $accessTokenStorage, $refreshTokenStorage, $config);
$server->addResponseType($jwtTokenResponseType, 'token');
```