### PR TITLE
Callable for customizing JWT payload

### DIFF
--- a/src/OAuth2/ResponseType/JwtAccessToken.php
+++ b/src/OAuth2/ResponseType/JwtAccessToken.php
@@ -128,15 +128,15 @@ class JwtAccessToken extends AccessToken
             'scope'      => $scope
         );
         
-        if (isset($this->config['jwt_extra_payload'])) {
-            if (!is_callable($this->config['jwt_extra_payload'])) {
-                throw new \InvalidArgumentException("config['jwt_extra_payload'] is not callable");
+        if (isset($this->config['jwt_extra_payload_callable'])) {
+            if (!is_callable($this->config['jwt_extra_payload_callable'])) {
+                throw new \InvalidArgumentException("config['jwt_extra_payload_callable'] is not callable");
             }
             
-            $extra = call_user_func($this->config['jwt_extra_payload'], $client_id, $user_id, $scope);
+            $extra = call_user_func($this->config['jwt_extra_payload_callable'], $client_id, $user_id, $scope);
             
             if (!is_array($extra)) {
-                throw new \InvalidArgumentException("config['jwt_extra_payload'] callable must return array");
+                throw new \InvalidArgumentException("config['jwt_extra_payload_callable'] callable must return array");
             }
             
             $payload = array_merge($extra, $payload);

--- a/src/OAuth2/ResponseType/JwtAccessToken.php
+++ b/src/OAuth2/ResponseType/JwtAccessToken.php
@@ -130,13 +130,13 @@ class JwtAccessToken extends AccessToken
         
         if (isset($this->config['jwt_extra_payload_callable'])) {
             if (!is_callable($this->config['jwt_extra_payload_callable'])) {
-                throw new \InvalidArgumentException("config['jwt_extra_payload_callable'] is not callable");
+                throw new \InvalidArgumentException('jwt_extra_payload_callable is not callable');
             }
             
             $extra = call_user_func($this->config['jwt_extra_payload_callable'], $client_id, $user_id, $scope);
             
             if (!is_array($extra)) {
-                throw new \InvalidArgumentException("config['jwt_extra_payload_callable'] callable must return array");
+                throw new \InvalidArgumentException('jwt_extra_payload_callable must return array');
             }
             
             $payload = array_merge($extra, $payload);

--- a/src/OAuth2/ResponseType/JwtAccessToken.php
+++ b/src/OAuth2/ResponseType/JwtAccessToken.php
@@ -129,16 +129,17 @@ class JwtAccessToken extends AccessToken
         );
         
         if (isset($this->config['jwt_extra_payload'])) {
-            if (is_callable($this->config['jwt_extra_payload'])) {
-                $extra = call_user_func($this->config['jwt_extra_payload'], $client_id, $user_id, $scope);
-                if (is_array($extra)) {
-                    $payload = array_merge($extra, $payload);
-                } else {
-                    throw new \InvalidArgumentException("config['jwt_extra_payload'] callable must return array");
-                }
-            } else {
+            if (!is_callable($this->config['jwt_extra_payload'])) {
                 throw new \InvalidArgumentException("config['jwt_extra_payload'] is not callable");
             }
+            
+            $extra = call_user_func($this->config['jwt_extra_payload'], $client_id, $user_id, $scope);
+            
+            if (!is_array($extra)) {
+                throw new \InvalidArgumentException("config['jwt_extra_payload'] callable must return array");
+            }
+            
+            $payload = array_merge($extra, $payload);
         }
         
         return $payload;

--- a/src/OAuth2/ResponseType/JwtAccessToken.php
+++ b/src/OAuth2/ResponseType/JwtAccessToken.php
@@ -116,7 +116,7 @@ class JwtAccessToken extends AccessToken
         $expires = time() + $this->config['access_lifetime'];
         $id = $this->generateAccessToken();
 
-        return array(
+        $payload = array(
             'id'         => $id, // for BC (see #591)
             'jti'        => $id,
             'iss'        => $this->config['issuer'],
@@ -127,5 +127,15 @@ class JwtAccessToken extends AccessToken
             'token_type' => $this->config['token_type'],
             'scope'      => $scope
         );
+        
+        if (isset($this->config['jwt_extra_payload']) && is_callable($this->config['jwt_extra_payload'])) {
+            $func = $this->config['jwt_extra_payload'];
+            $extra = $func($client_id, $user_id, $scope);
+            if (is_array($extra)) {
+                $payload = array_merge($extra, $payload);
+            }
+        }
+        
+        return $payload;
     }
 }

--- a/src/OAuth2/ResponseType/JwtAccessToken.php
+++ b/src/OAuth2/ResponseType/JwtAccessToken.php
@@ -128,11 +128,14 @@ class JwtAccessToken extends AccessToken
             'scope'      => $scope
         );
         
-        if (isset($this->config['jwt_extra_payload']) && is_callable($this->config['jwt_extra_payload'])) {
-            $func = $this->config['jwt_extra_payload'];
-            $extra = $func($client_id, $user_id, $scope);
-            if (is_array($extra)) {
-                $payload = array_merge($extra, $payload);
+        if (isset($this->config['jwt_extra_payload'])) {
+            if (is_callable($this->config['jwt_extra_payload'])) {
+                $extra = call_user_func($this->config['jwt_extra_payload'], $client_id, $user_id, $scope);
+                if (is_array($extra)) {
+                    $payload = array_merge($extra, $payload);
+                }
+            } else {
+                throw new \InvalidArgumentException("config['jwt_extra_payload'] is not callable");
             }
         }
         

--- a/src/OAuth2/ResponseType/JwtAccessToken.php
+++ b/src/OAuth2/ResponseType/JwtAccessToken.php
@@ -133,6 +133,8 @@ class JwtAccessToken extends AccessToken
                 $extra = call_user_func($this->config['jwt_extra_payload'], $client_id, $user_id, $scope);
                 if (is_array($extra)) {
                     $payload = array_merge($extra, $payload);
+                } else {
+                    throw new \InvalidArgumentException("config['jwt_extra_payload'] callable must return array");
                 }
             } else {
                 throw new \InvalidArgumentException("config['jwt_extra_payload'] is not callable");

--- a/src/OAuth2/Server.php
+++ b/src/OAuth2/Server.php
@@ -139,7 +139,7 @@ class Server implements ResourceControllerInterface,
         // merge all config values.  These get passed to our controller objects
         $this->config = array_merge(array(
             'use_jwt_access_tokens'        => false,
-            'jwt_extra_payload'        => null,
+            'jwt_extra_payload_callable' => null,
             'store_encrypted_token_string' => true,
             'use_openid_connect'       => false,
             'id_lifetime'              => 3600,
@@ -759,7 +759,7 @@ class Server implements ResourceControllerInterface,
             $refreshStorage = $this->storages['refresh_token'];
         }
 
-        $config = array_intersect_key($this->config, array_flip(explode(' ', 'store_encrypted_token_string issuer access_lifetime refresh_token_lifetime jwt_extra_payload')));
+        $config = array_intersect_key($this->config, array_flip(explode(' ', 'store_encrypted_token_string issuer access_lifetime refresh_token_lifetime jwt_extra_payload_callable')));
 
         return new JwtAccessToken($this->storages['public_key'], $tokenStorage, $refreshStorage, $config);
     }

--- a/src/OAuth2/Server.php
+++ b/src/OAuth2/Server.php
@@ -139,6 +139,7 @@ class Server implements ResourceControllerInterface,
         // merge all config values.  These get passed to our controller objects
         $this->config = array_merge(array(
             'use_jwt_access_tokens'        => false,
+            'jwt_extra_payload'        => null,
             'store_encrypted_token_string' => true,
             'use_openid_connect'       => false,
             'id_lifetime'              => 3600,

--- a/src/OAuth2/Server.php
+++ b/src/OAuth2/Server.php
@@ -758,7 +758,7 @@ class Server implements ResourceControllerInterface,
             $refreshStorage = $this->storages['refresh_token'];
         }
 
-        $config = array_intersect_key($this->config, array_flip(explode(' ', 'store_encrypted_token_string issuer access_lifetime refresh_token_lifetime')));
+        $config = array_intersect_key($this->config, array_flip(explode(' ', 'store_encrypted_token_string issuer access_lifetime refresh_token_lifetime jwt_extra_payload')));
 
         return new JwtAccessToken($this->storages['public_key'], $tokenStorage, $refreshStorage, $config);
     }

--- a/test/OAuth2/ResponseType/JwtAccessTokenTest.php
+++ b/test/OAuth2/ResponseType/JwtAccessTokenTest.php
@@ -42,7 +42,7 @@ class JwtAccessTokenTest extends \PHPUnit_Framework_TestCase
     
     public function testExtraPayloadCallback()
     {
-        $jwtconfig = array('jwt_extra_payload' => function() {
+        $jwtconfig = array('jwt_extra_payload_callable' => function() {
             return array('custom_param' => 'custom_value');
         });
         

--- a/test/OAuth2/ResponseType/JwtAccessTokenTest.php
+++ b/test/OAuth2/ResponseType/JwtAccessTokenTest.php
@@ -39,6 +39,23 @@ class JwtAccessTokenTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(3600, $delta);
         $this->assertEquals($decodedAccessToken['id'], $decodedAccessToken['jti']);
     }
+    
+    public function testExtraPayloadCallback()
+    {
+        $jwtconfig = array('jwt_extra_payload', function() {
+            return array('custom_param' => 'custom_value');
+        });
+        
+        $server = $this->getTestServer($jwtconfig);
+        $jwtResponseType = $server->getResponseType('token');
+        
+        $accessToken = $jwtResponseType->createAccessToken('Test Client ID', 123, 'test', false);
+        $jwt = new Jwt;
+        $decodedAccessToken = $jwt->decode($accessToken['access_token'], null, false);
+        
+        $this->assertArrayHasKey('custom_param', $decodedAccessToken);
+        $this->assertEquals('custom_value', $decodedAccessToken['custom_param']);
+    }
 
     public function testGrantJwtAccessToken()
     {
@@ -139,7 +156,7 @@ class JwtAccessTokenTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($response->getParameter('access_token'));
     }
 
-    private function getTestServer()
+    private function getTestServer($jwtconfig = array())
     {
         $memoryStorage = Bootstrap::getInstance()->getMemoryStorage();
 
@@ -152,7 +169,7 @@ class JwtAccessTokenTest extends \PHPUnit_Framework_TestCase
         $server->addGrantType(new ClientCredentials($memoryStorage));
 
         // make the "token" response type a JwtAccessToken
-        $config = array('issuer' => 'https://api.example.com');
+        $config = array_merge(array('issuer' => 'https://api.example.com'), $jwtconfig);
         $server->addResponseType(new JwtAccessToken($memoryStorage, $memoryStorage, null, $config));
 
         return $server;

--- a/test/OAuth2/ResponseType/JwtAccessTokenTest.php
+++ b/test/OAuth2/ResponseType/JwtAccessTokenTest.php
@@ -42,7 +42,7 @@ class JwtAccessTokenTest extends \PHPUnit_Framework_TestCase
     
     public function testExtraPayloadCallback()
     {
-        $jwtconfig = array('jwt_extra_payload', function() {
+        $jwtconfig = array('jwt_extra_payload' => function() {
             return array('custom_param' => 'custom_value');
         });
         


### PR DESCRIPTION
Even easier way for customizing JWT payload

Issue #750 
Issue #793
PR #795 

Usage:
```php
$myapp = .... // $myapp may be instance of your application or Service Container
$server = new OAuth2\Server($storage, array(
    'use_jwt_access_tokens' => true,
    'jwt_extra_payload' => function($client_id, $user_id, $scope) use ($myapp) {
        $data = $myapp->getSomeData();
        return array(
            'custom_param' => $data['something_important']
        );
    }
));
```

one more example:
```php
$myapp = .... // $myapp may be instance of your application or Service Container
$server = new OAuth2\Server($storage, array(
    'use_jwt_access_tokens' => true,
    'jwt_extra_payload' => array($myapp, 'getSomeData')
));
```
