### PR TITLE
Bearer::getAccessTokenParameter: added application/json into content-type evaluation

### DIFF
--- a/src/OAuth2/TokenType/Bearer.php
+++ b/src/OAuth2/TokenType/Bearer.php
@@ -113,7 +113,7 @@ class Bearer implements TokenTypeInterface
                 $contentType = substr($contentType, 0, $pos);
             }
 
-            if ($contentType !== null && $contentType != 'application/x-www-form-urlencoded') {
+            if ($contentType !== null && !in_array($contentType, array('application/x-www-form-urlencoded','application/json', true)) {
                 // IETF specifies content-type. NB: Not all webservers populate this _SERVER variable
                 // @see http://tools.ietf.org/html/rfc6750#section-2.2
                 $response->setError(400, 'invalid_request', 'The content type for POST requests must be "application/x-www-form-urlencoded"');

--- a/src/OAuth2/TokenType/Bearer.php
+++ b/src/OAuth2/TokenType/Bearer.php
@@ -113,7 +113,7 @@ class Bearer implements TokenTypeInterface
                 $contentType = substr($contentType, 0, $pos);
             }
 
-            if ($contentType !== null && !in_array($contentType, array('application/x-www-form-urlencoded','application/json', true)) {
+            if ($contentType !== null && !in_array($contentType, array('application/x-www-form-urlencoded','application/json', true))) {
                 // IETF specifies content-type. NB: Not all webservers populate this _SERVER variable
                 // @see http://tools.ietf.org/html/rfc6750#section-2.2
                 $response->setError(400, 'invalid_request', 'The content type for POST requests must be "application/x-www-form-urlencoded"');


### PR DESCRIPTION
It can be useful to add 'application/json' together with 'application/x-www-form-urlencoded' in the content-type white list. 
From what written in the resource _http://tools.ietf.org/html/rfc6750#section-2.2_ pointed in the code comment, the IETF clearly specifies to use 'application/x-www-form-urlencoded'

> The HTTP request entity-header includes the "Content-Type" header field set to "application/x-www-form-urlencoded".

If there are no added security issues that I cannot see at the moment, you can merge the pull request.