### PR TITLE
Fix buildUri for URIs with fragments

### DIFF
--- a/src/OAuth2/Controller/AuthorizeController.php
+++ b/src/OAuth2/Controller/AuthorizeController.php
@@ -376,8 +376,8 @@ class AuthorizeController implements AuthorizeControllerInterface
             . ((isset($parse_url["host"])) ? $parse_url["host"] : "")
             . ((isset($parse_url["port"])) ? ":" . $parse_url["port"] : "")
             . ((isset($parse_url["path"])) ? $parse_url["path"] : "")
-            . ((isset($parse_url["query"]) && !empty($parse_url['query'])) ? "?" . $parse_url["query"] : "")
             . ((isset($parse_url["fragment"])) ? "#" . $parse_url["fragment"] : "")
+            . ((isset($parse_url["query"]) && !empty($parse_url['query'])) ? "?" . $parse_url["query"] : "")
         ;
     }
 


### PR DESCRIPTION
Output the query part after the fragment part, otherwise redirect URIs with fragment don't work.

Example:
Given Redirect URI: https://www.example.com/#/oauth2
Result of buildUri before change: https://www.example.com/?code=2sadkfa3378dsadj&state=1#/oauth2
Result after change: https://www.example.com/#/oauth2?code=2sadkfa3378dsadj&state=1
