### PR TITLE
fix AuthorizeController scope error field

### DIFF
--- a/src/OAuth2/Controller/AuthorizeController.php
+++ b/src/OAuth2/Controller/AuthorizeController.php
@@ -247,7 +247,7 @@ class AuthorizeController implements AuthorizeControllerInterface
             $defaultScope = $this->scopeUtil->getDefaultScope($client_id);
 
             if (false === $defaultScope) {
-                $response->setRedirect($this->config['redirect_status_code'], $redirect_uri, $state, 'invalid_client', 'This application requires you specify a scope parameter', null);
+                $response->setRedirect($this->config['redirect_status_code'], $redirect_uri, $state, 'invalid_scope', 'This application requires you specify a scope parameter', null);
 
                 return false;
             }

--- a/test/OAuth2/Controller/AuthorizeControllerTest.php
+++ b/test/OAuth2/Controller/AuthorizeControllerTest.php
@@ -153,7 +153,7 @@ class AuthorizeControllerTest extends \PHPUnit_Framework_TestCase
         $parts = parse_url($response->getHttpHeader('Location'));
         parse_str($parts['query'], $query);
 
-        $this->assertEquals($query['error'], 'invalid_client');
+        $this->assertEquals($query['error'], 'invalid_scope');
         $this->assertEquals($query['error_description'], 'This application requires you specify a scope parameter');
 
         $request->query['scope'] = 'testscope';


### PR DESCRIPTION
According to the rfc https://tools.ietf.org/html/rfc6749#section-4.1.2.1
scope errors should have an error field of invalid_scope this fixes that
and the test.  The TokenController has the same error description but
uses the invalid_scope error so this commit makes AuthorizeController
match that.