### PR TITLE
Merge headers with server global header values

### DIFF
--- a/src/OAuth2/Request.php
+++ b/src/OAuth2/Request.php
@@ -64,7 +64,12 @@ class Request implements RequestInterface
         $this->files = $files;
         $this->server = $server;
         $this->content = $content;
-        $this->headers = is_null($headers) ? $this->getHeadersFromServer($this->server) : $headers;
+
+        if ($headers === null) {
+            $headers = array();
+        }
+
+        $this->headers = $headers + $this->getHeadersFromServer($this->server);
     }
 
     /**

--- a/test/OAuth2/RequestTest.php
+++ b/test/OAuth2/RequestTest.php
@@ -85,6 +85,24 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('correct', $request->query('client_id', $request->request('client_id')));
     }
 
+    public function testRequestHasHeadersAndServerHeaders()
+    {
+        $request = new Request(
+            array(),
+            array(),
+            array(),
+            array(),
+            array(),
+            array('CONTENT_TYPE' => 'text/xml', 'PHP_AUTH_USER' => 'client_id', 'PHP_AUTH_PW' => 'client_pass'),
+            null,
+            array('CONTENT_TYPE' => 'application/json')
+        );
+
+        $this->assertSame('client_id', $request->headers('PHP_AUTH_USER'));
+        $this->assertSame('client_pass', $request->headers('PHP_AUTH_PW'));
+        $this->assertSame('application/json', $request->headers('CONTENT_TYPE'));
+    }
+
     private function getTestServer($config = array())
     {
         $storage = Bootstrap::getInstance()->getMemoryStorage();


### PR DESCRIPTION
This pull request allows headers to be merged with server global header values with precedence given to the `$headers` array. 