### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/test/OAuth2/AutoloadTest.php
+++ b/test/OAuth2/AutoloadTest.php
@@ -2,7 +2,9 @@
 
 namespace OAuth2;
 
-class AutoloadTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AutoloadTest extends TestCase
 {
     public function testClassesExist()
     {

--- a/test/OAuth2/Controller/AuthorizeControllerTest.php
+++ b/test/OAuth2/Controller/AuthorizeControllerTest.php
@@ -10,8 +10,9 @@ use OAuth2\GrantType\AuthorizationCode;
 use OAuth2\Request;
 use OAuth2\Response;
 use OAuth2\Request\TestRequest;
+use PHPUnit\Framework\TestCase;
 
-class AuthorizeControllerTest extends \PHPUnit_Framework_TestCase
+class AuthorizeControllerTest extends TestCase
 {
     public function testNoClientIdResponse()
     {

--- a/test/OAuth2/Controller/ResourceControllerTest.php
+++ b/test/OAuth2/Controller/ResourceControllerTest.php
@@ -7,8 +7,9 @@ use OAuth2\Server;
 use OAuth2\GrantType\AuthorizationCode;
 use OAuth2\Request;
 use OAuth2\Response;
+use PHPUnit\Framework\TestCase;
 
-class ResourceControllerTest extends \PHPUnit_Framework_TestCase
+class ResourceControllerTest extends TestCase
 {
     public function testNoAccessToken()
     {

--- a/test/OAuth2/Controller/TokenControllerTest.php
+++ b/test/OAuth2/Controller/TokenControllerTest.php
@@ -10,8 +10,9 @@ use OAuth2\GrantType\UserCredentials;
 use OAuth2\Scope;
 use OAuth2\Request\TestRequest;
 use OAuth2\Response;
+use PHPUnit\Framework\TestCase;
 
-class TokenControllerTest extends \PHPUnit_Framework_TestCase
+class TokenControllerTest extends TestCase
 {
     public function testNoGrantType()
     {

--- a/test/OAuth2/Encryption/FirebaseJwtTest.php
+++ b/test/OAuth2/Encryption/FirebaseJwtTest.php
@@ -3,8 +3,9 @@
 namespace OAuth2\Encryption;
 
 use OAuth2\Storage\Bootstrap;
+use PHPUnit\Framework\TestCase;
 
-class FirebaseJwtTest extends \PHPUnit_Framework_TestCase
+class FirebaseJwtTest extends TestCase
 {
     private $privateKey;
 

--- a/test/OAuth2/Encryption/JwtTest.php
+++ b/test/OAuth2/Encryption/JwtTest.php
@@ -3,8 +3,9 @@
 namespace OAuth2\Encryption;
 
 use OAuth2\Storage\Bootstrap;
+use PHPUnit\Framework\TestCase;
 
-class JwtTest extends \PHPUnit_Framework_TestCase
+class JwtTest extends TestCase
 {
     private $privateKey;
 

--- a/test/OAuth2/GrantType/AuthorizationCodeTest.php
+++ b/test/OAuth2/GrantType/AuthorizationCodeTest.php
@@ -6,8 +6,9 @@ use OAuth2\Storage\Bootstrap;
 use OAuth2\Server;
 use OAuth2\Request\TestRequest;
 use OAuth2\Response;
+use PHPUnit\Framework\TestCase;
 
-class AuthorizationCodeTest extends \PHPUnit_Framework_TestCase
+class AuthorizationCodeTest extends TestCase
 {
     public function testNoCode()
     {

--- a/test/OAuth2/GrantType/ClientCredentialsTest.php
+++ b/test/OAuth2/GrantType/ClientCredentialsTest.php
@@ -7,8 +7,9 @@ use OAuth2\Server;
 use OAuth2\Request\TestRequest;
 use OAuth2\Request;
 use OAuth2\Response;
+use PHPUnit\Framework\TestCase;
 
-class ClientCredentialsTest extends \PHPUnit_Framework_TestCase
+class ClientCredentialsTest extends TestCase
 {
     public function testInvalidCredentials()
     {

--- a/test/OAuth2/GrantType/ImplicitTest.php
+++ b/test/OAuth2/GrantType/ImplicitTest.php
@@ -6,8 +6,9 @@ use OAuth2\Storage\Bootstrap;
 use OAuth2\Server;
 use OAuth2\Request;
 use OAuth2\Response;
+use PHPUnit\Framework\TestCase;
 
-class ImplicitTest extends \PHPUnit_Framework_TestCase
+class ImplicitTest extends TestCase
 {
     public function testImplicitNotAllowedResponse()
     {

--- a/test/OAuth2/GrantType/JwtBearerTest.php
+++ b/test/OAuth2/GrantType/JwtBearerTest.php
@@ -7,8 +7,9 @@ use OAuth2\Server;
 use OAuth2\Request\TestRequest;
 use OAuth2\Response;
 use OAuth2\Encryption\Jwt;
+use PHPUnit\Framework\TestCase;
 
-class JwtBearerTest extends \PHPUnit_Framework_TestCase
+class JwtBearerTest extends TestCase
 {
     private $privateKey;
 

--- a/test/OAuth2/GrantType/RefreshTokenTest.php
+++ b/test/OAuth2/GrantType/RefreshTokenTest.php
@@ -6,8 +6,9 @@ use OAuth2\Storage\Bootstrap;
 use OAuth2\Server;
 use OAuth2\Request\TestRequest;
 use OAuth2\Response;
+use PHPUnit\Framework\TestCase;
 
-class RefreshTokenTest extends \PHPUnit_Framework_TestCase
+class RefreshTokenTest extends TestCase
 {
     private $storage;
 

--- a/test/OAuth2/GrantType/UserCredentialsTest.php
+++ b/test/OAuth2/GrantType/UserCredentialsTest.php
@@ -6,8 +6,9 @@ use OAuth2\Storage\Bootstrap;
 use OAuth2\Server;
 use OAuth2\Request\TestRequest;
 use OAuth2\Response;
+use PHPUnit\Framework\TestCase;
 
-class UserCredentialsTest extends \PHPUnit_Framework_TestCase
+class UserCredentialsTest extends TestCase
 {
     public function testNoUsername()
     {

--- a/test/OAuth2/OpenID/Controller/AuthorizeControllerTest.php
+++ b/test/OAuth2/OpenID/Controller/AuthorizeControllerTest.php
@@ -6,8 +6,9 @@ use OAuth2\Storage\Bootstrap;
 use OAuth2\Server;
 use OAuth2\Request;
 use OAuth2\Response;
+use PHPUnit\Framework\TestCase;
 
-class AuthorizeControllerTest extends \PHPUnit_Framework_TestCase
+class AuthorizeControllerTest extends TestCase
 {
     public function testValidateAuthorizeRequest()
     {

--- a/test/OAuth2/OpenID/Controller/UserInfoControllerTest.php
+++ b/test/OAuth2/OpenID/Controller/UserInfoControllerTest.php
@@ -6,8 +6,9 @@ use OAuth2\Storage\Bootstrap;
 use OAuth2\Server;
 use OAuth2\Request;
 use OAuth2\Response;
+use PHPUnit\Framework\TestCase;
 
-class UserInfoControllerTest extends \PHPUnit_Framework_TestCase
+class UserInfoControllerTest extends TestCase
 {
     public function testCreateController()
     {

--- a/test/OAuth2/OpenID/GrantType/AuthorizationCodeTest.php
+++ b/test/OAuth2/OpenID/GrantType/AuthorizationCodeTest.php
@@ -6,8 +6,9 @@ use OAuth2\Storage\Bootstrap;
 use OAuth2\Server;
 use OAuth2\Request\TestRequest;
 use OAuth2\Response;
+use PHPUnit\Framework\TestCase;
 
-class AuthorizationCodeTest extends \PHPUnit_Framework_TestCase
+class AuthorizationCodeTest extends TestCase
 {
     public function testValidCode()
     {

--- a/test/OAuth2/OpenID/ResponseType/CodeIdTokenTest.php
+++ b/test/OAuth2/OpenID/ResponseType/CodeIdTokenTest.php
@@ -7,8 +7,9 @@ use OAuth2\Request;
 use OAuth2\Response;
 use OAuth2\Storage\Bootstrap;
 use OAuth2\GrantType\ClientCredentials;
+use PHPUnit\Framework\TestCase;
 
-class CodeIdTokenTest extends \PHPUnit_Framework_TestCase
+class CodeIdTokenTest extends TestCase
 {
     public function testHandleAuthorizeRequest()
     {

--- a/test/OAuth2/OpenID/ResponseType/IdTokenTest.php
+++ b/test/OAuth2/OpenID/ResponseType/IdTokenTest.php
@@ -8,8 +8,9 @@ use OAuth2\Response;
 use OAuth2\Storage\Bootstrap;
 use OAuth2\GrantType\ClientCredentials;
 use OAuth2\Encryption\Jwt;
+use PHPUnit\Framework\TestCase;
 
-class IdTokenTest extends \PHPUnit_Framework_TestCase
+class IdTokenTest extends TestCase
 {
     public function testValidateAuthorizeRequest()
     {

--- a/test/OAuth2/OpenID/ResponseType/IdTokenTokenTest.php
+++ b/test/OAuth2/OpenID/ResponseType/IdTokenTokenTest.php
@@ -8,8 +8,9 @@ use OAuth2\Response;
 use OAuth2\Storage\Bootstrap;
 use OAuth2\GrantType\ClientCredentials;
 use OAuth2\ResponseType\AccessToken;
+use PHPUnit\Framework\TestCase;
 
-class IdTokenTokenTest extends \PHPUnit_Framework_TestCase
+class IdTokenTokenTest extends TestCase
 {
 
     public function testHandleAuthorizeRequest()

--- a/test/OAuth2/RequestTest.php
+++ b/test/OAuth2/RequestTest.php
@@ -5,8 +5,9 @@ namespace OAuth2;
 use OAuth2\Request\TestRequest;
 use OAuth2\Storage\Bootstrap;
 use OAuth2\GrantType\AuthorizationCode;
+use PHPUnit\Framework\TestCase;
 
-class RequestTest extends \PHPUnit_Framework_TestCase
+class RequestTest extends TestCase
 {
     public function testRequestOverride()
     {

--- a/test/OAuth2/ResponseTest.php
+++ b/test/OAuth2/ResponseTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace OAuth2;
+namespace OAuth2;use PHPUnit\Framework\TestCase;
 
-class ResponseTest extends \PHPUnit_Framework_TestCase
+class ResponseTest extends TestCase
 {
     public function testRenderAsXml()
     {

--- a/test/OAuth2/ResponseType/AccessTokenTest.php
+++ b/test/OAuth2/ResponseType/AccessTokenTest.php
@@ -4,8 +4,9 @@ namespace OAuth2\ResponseType;
 
 use OAuth2\Server;
 use OAuth2\Storage\Memory;
+use PHPUnit\Framework\TestCase;
 
-class AccessTokenTest extends \PHPUnit_Framework_TestCase
+class AccessTokenTest extends TestCase
 {
     public function testRevokeAccessTokenWithTypeHint()
     {

--- a/test/OAuth2/ResponseType/JwtAccessTokenTest.php
+++ b/test/OAuth2/ResponseType/JwtAccessTokenTest.php
@@ -11,8 +11,9 @@ use OAuth2\GrantType\ClientCredentials;
 use OAuth2\GrantType\UserCredentials;
 use OAuth2\GrantType\RefreshToken;
 use OAuth2\Encryption\Jwt;
+use PHPUnit\Framework\TestCase;
 
-class JwtAccessTokenTest extends \PHPUnit_Framework_TestCase
+class JwtAccessTokenTest extends TestCase
 {
     public function testCreateAccessToken()
     {

--- a/test/OAuth2/ScopeTest.php
+++ b/test/OAuth2/ScopeTest.php
@@ -3,8 +3,9 @@
 namespace OAuth2;
 
 use OAuth2\Storage\Memory;
+use PHPUnit\Framework\TestCase;
 
-class ScopeTest extends \PHPUnit_Framework_TestCase
+class ScopeTest extends TestCase
 {
     public function testCheckScope()
     {

--- a/test/OAuth2/ServerTest.php
+++ b/test/OAuth2/ServerTest.php
@@ -5,8 +5,9 @@ namespace OAuth2;
 use OAuth2\Request\TestRequest;
 use OAuth2\ResponseType\AuthorizationCode;
 use OAuth2\Storage\Bootstrap;
+use PHPUnit\Framework\TestCase;
 
-class ServerTest extends \PHPUnit_Framework_TestCase
+class ServerTest extends TestCase
 {
     /**
      * @expectedException LogicException OAuth2\Storage\ClientInterface

--- a/test/OAuth2/TokenType/BearerTest.php
+++ b/test/OAuth2/TokenType/BearerTest.php
@@ -4,8 +4,9 @@ namespace OAuth2\TokenType;
 
 use OAuth2\Request\TestRequest;
 use OAuth2\Response;
+use PHPUnit\Framework\TestCase;
 
-class BearerTest extends \PHPUnit_Framework_TestCase
+class BearerTest extends TestCase
 {
     public function testValidContentTypeWithCharset()
     {

--- a/test/lib/OAuth2/Storage/BaseTest.php
+++ b/test/lib/OAuth2/Storage/BaseTest.php
@@ -2,7 +2,9 @@
 
 namespace OAuth2\Storage;
 
-abstract class BaseTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+abstract class BaseTest extends TestCase
 {
     public function provideStorage()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).