### PR TITLE
[Fix test] "Expiration (exp) time must be a unix time stamp" on 32-bit platform

### DIFF
--- a/test/OAuth2/GrantType/JwtBearerTest.php
+++ b/test/OAuth2/GrantType/JwtBearerTest.php
@@ -282,7 +282,7 @@ EOD;
         $server = $this->getTestServer();
         $request = TestRequest::createPost(array(
                 'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',  // valid grant type
-                'assertion' => $this->getJWT(99999999900, null, 'testuser@ourdomain.com', 'Test Client ID', 'used_jti'), // valid assertion with invalid scope
+                'assertion' => $this->getJWT(2147483647, null, 'testuser@ourdomain.com', 'Test Client ID', 'used_jti'), // valid assertion with invalid scope
         ));
         $token = $server->grantAccessToken($request, $response = new Response());
 
@@ -296,7 +296,7 @@ EOD;
         $server = $this->getTestServer();
         $request = TestRequest::createPost(array(
                 'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',  // valid grant type
-                'assertion' => $this->getJWT(99999999900, null, 'testuser@ourdomain.com', 'Test Client ID', 'totally_new_jti'), // valid assertion with invalid scope
+                'assertion' => $this->getJWT(null, null, 'testuser@ourdomain.com', 'Test Client ID', 'totally_new_jti'), // valid assertion with invalid scope
         ));
         $token = $server->grantAccessToken($request, $response = new Response());
 

--- a/test/config/storage.json
+++ b/test/config/storage.json
@@ -4,40 +4,40 @@
             "client_id": "Test Client ID",
             "user_id": "",
             "redirect_uri": "",
-            "expires": "9999999999",
+            "expires": 2147483647,
             "id_token": "IDTOKEN"
         },
         "testcode-with-scope": {
             "client_id": "Test Client ID",
             "user_id": "",
             "redirect_uri": "",
-            "expires": "9999999999",
+            "expires": 2147483647,
             "scope": "scope1 scope2"
         },
         "testcode-expired": {
             "client_id": "Test Client ID",
             "user_id": "",
             "redirect_uri": "",
-            "expires": "1356998400"
+            "expires": 1356998400
         },
         "testcode-empty-secret": {
             "client_id": "Test Client ID Empty Secret",
             "user_id": "",
             "redirect_uri": "",
-            "expires": "9999999999"
+            "expires": 2147483647
         },
         "testcode-openid": {
             "client_id": "Test Client ID",
             "user_id": "",
             "redirect_uri": "",
-            "expires": "9999999999",
+            "expires": 2147483647,
             "id_token": "test_id_token"
         },
         "testcode-redirect-uri": {
             "client_id": "Test Client ID",
             "user_id": "",
             "redirect_uri": "http://brentertainment.com/voil%C3%A0",
-            "expires": "9999999999",
+            "expires": 2147483647,
             "id_token": "IDTOKEN"
         }
     },
@@ -122,19 +122,19 @@
         "accesstoken-scope": {
             "access_token": "accesstoken-scope",
             "client_id": "Test Client ID",
-            "expires": 99999999900,
+            "expires": 2147483647,
             "scope": "testscope"
         },
         "accesstoken-openid-connect": {
             "access_token": "accesstoken-openid-connect",
             "client_id": "Test Client ID",
             "user_id": "testuser",
-            "expires": 99999999900,
+            "expires": 2147483647,
             "scope": "openid email"
         },
         "accesstoken-malformed": {
             "access_token": "accesstoken-mallformed",
-            "expires": 99999999900,
+            "expires": 2147483647,
             "scope": "testscope"
         }
     },
@@ -165,7 +165,7 @@
             "issuer": "Test Client ID",
             "subject": "testuser@ourdomain.com",
             "audience": "http://myapp.com/oauth/auth",
-            "expires": 99999999900,
+            "expires": 2147483647,
             "jti": "used_jti"
         }
     ],


### PR DESCRIPTION
After this PR #898 I able to run tests. And I get:
```
There were 2 failures:

1) OAuth2\GrantType\JwtBearerTest::testInvalidJti
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'Expiration (exp) time must be a unix time stamp'
+'JSON Token Identifier (jti) has already been used'

D:\eclipseworkspace\oauth2-server-php\test\OAuth2\GrantType\JwtBearerTest.php:291

2) OAuth2\GrantType\JwtBearerTest::testJtiReplayAttack
Failed asserting that null is not null.
```

Tests failed because `ctype_digit($jwt['exp'])` evals to `false` when `$jwt['exp']` is `double` (it becomes `double` when `$jwt['exp'] > PHP_INT_MAX`)
```php
// on 32-bit
$d = 99999999900;
var_dump($d, ctype_digit($d));
//double(99999999900) bool(false) 

$d = '99999999900';
var_dump($d, ctype_digit($d));
//string(11) "99999999900" bool(true) 

// on 64-bit
$d = 99999999900;
var_dump($d, ctype_digit($d));
//int(99999999900) bool(true) 

$d = '99999999900';
var_dump($d, ctype_digit($d));
//string(11) "99999999900" bool(true) 
```

To fix this we should always write big integers as strings (`'99999999900'`)
or write integers as integers (`12345`) and integers must be <= PHP_INT_MAX
