### PR TITLE
Make the ResponseInterface Symfony 4 compliant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ cache:
     - $HOME/.composer/cache
     - vendor
 php:
-- 5.3
-- 5.4
-- 5.5
-- 5.6
-- 7.0
 - 7.1
 - 7.2
 env:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "psr-0": { "OAuth2": "src/" }
     },
     "require":{
-        "php":">=5.3.9"
+        "php":"^7.1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0",

--- a/src/OAuth2/Response.php
+++ b/src/OAuth2/Response.php
@@ -140,13 +140,13 @@ class Response implements ResponseInterface
     }
 
     /**
-     * @param int $statusCode
-     * @param string $text
+     * @param int              $statusCode
+     * @param string|bool|null $text
      * @throws InvalidArgumentException
      */
-    public function setStatusCode($statusCode, $text = null)
+    public function setStatusCode(int $statusCode, $text = null)
     {
-        $this->statusCode = (int) $statusCode;
+        $this->statusCode = $statusCode;
         if ($this->isInvalid()) {
             throw new InvalidArgumentException(sprintf('The HTTP status code "%s" is not valid.', $statusCode));
         }

--- a/src/OAuth2/ResponseInterface.php
+++ b/src/OAuth2/ResponseInterface.php
@@ -21,9 +21,10 @@ interface ResponseInterface
     public function addHttpHeaders(array $httpHeaders);
 
     /**
-     * @param int $statusCode
+     * @param int              $statusCode
+     * @param string|bool|null $text
      */
-    public function setStatusCode($statusCode);
+    public function setStatusCode(int $statusCode, $text = null);
 
     /**
      * @param int    $statusCode


### PR DESCRIPTION
This is a breaking change as the interface is now type-hinted which means that the min PHP version had to be bumped (so this should be tagged as the next major version).

Fixes https://github.com/bshaffer/oauth2-server-httpfoundation-bridge/issues/31