### PR TITLE
Include Client ID (kid) parameter in the JWT header

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpunit/phpunit": "^4.0",
         "aws/aws-sdk-php": "~2.8",
-        "firebase/php-jwt": "~2.3",
+        "firebase/php-jwt": "~3.0",
         "predis/predis": "dev-master",
         "thobbs/phpcassa": "dev-master",
         "mongodb/mongodb": "^1.1"
@@ -30,7 +30,7 @@
         "predis/predis": "Required to use Redis storage",
         "thobbs/phpcassa": "Required to use Cassandra storage",
         "aws/aws-sdk-php": "~2.8 is required to use DynamoDB storage",
-        "firebase/php-jwt": "~2.3 is required to use JWT features",
+        "firebase/php-jwt": "~3.0 is required to use JWT features",
         "mongodb/mongodb": "^1.1 is required to use MongoDB storage"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpunit/phpunit": "^4.0",
         "aws/aws-sdk-php": "~2.8",
-        "firebase/php-jwt": "~2.2",
+        "firebase/php-jwt": "~2.3",
         "predis/predis": "dev-master",
         "thobbs/phpcassa": "dev-master",
         "mongodb/mongodb": "^1.1"
@@ -30,7 +30,7 @@
         "predis/predis": "Required to use Redis storage",
         "thobbs/phpcassa": "Required to use Cassandra storage",
         "aws/aws-sdk-php": "~2.8 is required to use DynamoDB storage",
-        "firebase/php-jwt": "~2.2 is required to use JWT features",
+        "firebase/php-jwt": "~2.3 is required to use JWT features",
         "mongodb/mongodb": "^1.1 is required to use MongoDB storage"
     }
 }

--- a/src/OAuth2/Encryption/EncryptionInterface.php
+++ b/src/OAuth2/Encryption/EncryptionInterface.php
@@ -10,7 +10,7 @@ interface EncryptionInterface
      * @param null $algorithm
      * @return mixed
      */
-    public function encode($payload, $key, $algorithm = null);
+    public function encode($payload, $key, $algorithm = null, $keyId = null);
 
     /**
      * @param $payload

--- a/src/OAuth2/Encryption/FirebaseJwt.php
+++ b/src/OAuth2/Encryption/FirebaseJwt.php
@@ -10,14 +10,14 @@ class FirebaseJwt implements EncryptionInterface
 {
     public function __construct()
     {
-        if (!class_exists('\JWT')) {
+        if (!class_exists('\Firebase\JWT\JWT')) {
             throw new \ErrorException('firebase/php-jwt must be installed to use this feature. You can do this by running "composer require firebase/php-jwt"');
         }
     }
 
     public function encode($payload, $key, $alg = 'HS256', $keyId = null)
     {
-        return \JWT::encode($payload, $key, $alg, $keyId);
+        return \Firebase\JWT\JWT::encode($payload, $key, $alg, $keyId);
     }
 
     public function decode($jwt, $key = null, $allowedAlgorithms = null)
@@ -29,7 +29,7 @@ class FirebaseJwt implements EncryptionInterface
                 $key = null;
             }
 
-            return (array)\JWT::decode($jwt, $key, $allowedAlgorithms);
+            return (array)\Firebase\JWT\JWT::decode($jwt, $key, $allowedAlgorithms);
         } catch (\Exception $e) {
             return false;
         }
@@ -37,11 +37,11 @@ class FirebaseJwt implements EncryptionInterface
 
     public function urlSafeB64Encode($data)
     {
-        return \JWT::urlsafeB64Encode($data);
+        return \Firebase\JWT\JWT::urlsafeB64Encode($data);
     }
 
     public function urlSafeB64Decode($b64)
     {
-        return \JWT::urlsafeB64Decode($b64);
+        return \Firebase\JWT\JWT::urlsafeB64Decode($b64);
     }
 }

--- a/src/OAuth2/Encryption/Jwt.php
+++ b/src/OAuth2/Encryption/Jwt.php
@@ -17,9 +17,9 @@ class Jwt implements EncryptionInterface
      * @param string $algo
      * @return string
      */
-    public function encode($payload, $key, $algo = 'HS256')
+    public function encode($payload, $key, $algo = 'HS256', $keyId = null)
     {
-        $header = $this->generateJwtHeader($payload, $algo);
+        $header = $this->generateJwtHeader($payload, $algo, $keyId);
 
         $segments = array(
             $this->urlSafeB64Encode(json_encode($header)),
@@ -195,12 +195,16 @@ class Jwt implements EncryptionInterface
     /**
      * Override to create a custom header
      */
-    protected function generateJwtHeader($payload, $algorithm)
+    protected function generateJwtHeader($payload, $algorithm, $keyId = null)
     {
-        return array(
+        $header = array(
             'typ' => 'JWT',
             'alg' => $algorithm,
         );
+        if (!is_null($keyId)) {
+            $header['kid'] = $keyId;
+        }
+        return $header;
     }
 
     /**

--- a/src/OAuth2/OpenID/ResponseType/IdToken.php
+++ b/src/OAuth2/OpenID/ResponseType/IdToken.php
@@ -144,7 +144,7 @@ class IdToken implements IdTokenInterface
         $private_key = $this->publicKeyStorage->getPrivateKey($client_id);
         $algorithm = $this->publicKeyStorage->getEncryptionAlgorithm($client_id);
 
-        return $this->encryptionUtil->encode($token, $private_key, $algorithm);
+        return $this->encryptionUtil->encode($token, $private_key, $algorithm, $client_id);
     }
 
     /**

--- a/src/OAuth2/ResponseType/JwtAccessToken.php
+++ b/src/OAuth2/ResponseType/JwtAccessToken.php
@@ -111,7 +111,7 @@ class JwtAccessToken extends AccessToken
         $private_key = $this->publicKeyStorage->getPrivateKey($client_id);
         $algorithm   = $this->publicKeyStorage->getEncryptionAlgorithm($client_id);
 
-        return $this->encryptionUtil->encode($token, $private_key, $algorithm);
+        return $this->encryptionUtil->encode($token, $private_key, $algorithm, $client_id);
     }
 
     /**


### PR DESCRIPTION
Currently, `Oauth2\Encryption\FirebaseJwt::encode` has a different signature from `OAuth2\Encryption\Jwt::encode`; the `FirebaseJwt` function has an additional `$keyId` parameter.  This parameter, when included, is passed into the `kid` parameter of the JWT header.

Unfortunately, neither of the two classes which use it (`OAuth2\OpenID\ResponseType\IdToken` and `OAuth2\ResponseType\JwtAccessToken`) include the parameter by default, so a lot of code is required to get this parameter added into the JWT header.

This PR modifies the signature of `OAuth2\Encryption\EncryptionInterface::encode` to include the `$keyId` parameter, thus standardizing between the two provided encryption implementations to offer a way to incorporate the `kid` parameter.  It also modifies the two ResponseTypes which use the `encode` method to pass the `$client_id`.

There is also one more related issue included in this PR: modern versions of firebase/php-jwt use namespaces, while the references in `Oauth2\Encryption\FirebaseJwt` do not.  I've modified this class to use the proper namespace parameters, and also upgraded the minimum suggestion of firebase/php-jwt package from ~2.2 (released 2015-06-22) to ~3.0 (released 2015-07-22).