### PR TITLE
Modified response code 400 to 401

### DIFF
--- a/src/OAuth2/ClientAssertionType/HttpBasic.php
+++ b/src/OAuth2/ClientAssertionType/HttpBasic.php
@@ -71,7 +71,7 @@ class HttpBasic implements ClientAssertionTypeInterface
                 return false;
             }
         } elseif ($this->storage->checkClientCredentials($clientData['client_id'], $clientData['client_secret']) === false) {
-            $response->setError(400, 'invalid_client', 'The client credentials are invalid');
+            $response->setError(401, 'invalid_client', 'The client credentials are invalid');
 
             return false;
         }

--- a/test/OAuth2/Controller/TokenControllerTest.php
+++ b/test/OAuth2/Controller/TokenControllerTest.php
@@ -96,7 +96,7 @@ class TokenControllerTest extends TestCase
         ));
         $server->handleTokenRequest($request, $response = new Response());
 
-        $this->assertEquals($response->getStatusCode(), 400);
+        $this->assertEquals($response->getStatusCode(), 401);
         $this->assertEquals($response->getParameter('error'), 'invalid_client');
         $this->assertEquals($response->getParameter('error_description'), 'The client credentials are invalid');
     }
@@ -113,7 +113,7 @@ class TokenControllerTest extends TestCase
         ));
         $server->handleTokenRequest($request, $response = new Response());
 
-        $this->assertEquals($response->getStatusCode(), 400);
+        $this->assertEquals($response->getStatusCode(), 401);
         $this->assertEquals($response->getParameter('error'), 'invalid_client');
         $this->assertEquals($response->getParameter('error_description'), 'The client credentials are invalid');
     }


### PR DESCRIPTION
When passing invalid client credentials (either client_id or client_secret) when requesting an access token, instead of returning a 400 response code, it should be returning a 401 response code for unauthorized. Limited it to the case where all conditions (public/non public etc) are passed and its only about the credentials. TokenControllerTest modified accordingly.