### PR TITLE
Treat missing client_id as public client

### DIFF
--- a/src/OAuth2/ClientAssertionType/HttpBasic.php
+++ b/src/OAuth2/ClientAssertionType/HttpBasic.php
@@ -51,7 +51,7 @@ class HttpBasic implements ClientAssertionTypeInterface
     public function validateRequest(RequestInterface $request, ResponseInterface $response)
     {
         if (!$clientData = $this->getClientCredentials($request, $response)) {
-            return false;
+            $clientData = array('client_id' => '', 'client_secret' => '');
         }
 
         if (!isset($clientData['client_id'])) {
@@ -130,8 +130,11 @@ class HttpBasic implements ClientAssertionTypeInterface
         }
 
         if ($response) {
-            $message = $this->config['allow_credentials_in_request_body'] ? ' or body' : '';
-            $response->setError(400, 'invalid_client', 'Client credentials were not found in the headers'.$message);
+            // Only consider not having client credentials a problem when public_clients are not allowed
+            if (!$this->config['allow_public_clients']){
+                $message = $this->config['allow_credentials_in_request_body'] ? ' or body' : '';
+                $response->setError(400, 'invalid_client', 'Client credentials were not found in the headers'.$message);
+            }
         }
 
         return null;

--- a/src/OAuth2/Storage/Pdo.php
+++ b/src/OAuth2/Storage/Pdo.php
@@ -105,7 +105,7 @@ class Pdo implements
      */
     public function isPublicClient($client_id)
     {
-		if (!$client_id || $client_id == ''){
+        if (!$client_id || $client_id == ''){
             return true;
         }
 		

--- a/src/OAuth2/Storage/Pdo.php
+++ b/src/OAuth2/Storage/Pdo.php
@@ -105,6 +105,10 @@ class Pdo implements
      */
     public function isPublicClient($client_id)
     {
+		if (!$client_id || $client_id == ''){
+            return true;
+        }
+		
         $stmt = $this->db->prepare(sprintf('SELECT * from %s where client_id = :client_id', $this->config['client_table']));
         $stmt->execute(compact('client_id'));
 

--- a/test/OAuth2/Controller/TokenControllerTest.php
+++ b/test/OAuth2/Controller/TokenControllerTest.php
@@ -39,21 +39,6 @@ class TokenControllerTest extends TestCase
         $this->assertEquals($response->getParameter('error_description'), 'Grant type "invalid_grant_type" not supported');
     }
 
-    public function testNoClientId()
-    {
-        // add the test parameters in memory
-        $server = $this->getTestServer();
-        $request = TestRequest::createPost(array(
-            'grant_type' => 'authorization_code', // valid grant type
-            'code'       => 'testcode',
-        ));
-        $server->handleTokenRequest($request, $response = new Response());
-
-        $this->assertEquals($response->getStatusCode(), 400);
-        $this->assertEquals($response->getParameter('error'), 'invalid_client');
-        $this->assertEquals($response->getParameter('error_description'), 'Client credentials were not found in the headers or body');
-    }
-
     public function testNoClientSecretWithConfidentialClient()
     {
         // add the test parameters in memory


### PR DESCRIPTION
When implementing this OAuth server I ran into the server not handling public clients as expected.

The server (imo) incorrectly expects all requests to contain the client_id field. For public clients there is no requirement for a client id to be included in the request.

I checked this against the RFC 6749 (section 2 specifically) and it does not explicitly state that this client_id is actually required or must be present for public clients. The only relevant information I can find:

> This specification does not exclude the use of unregistered clients. However, the use of such clients is beyond the scope of this specification

This PR makes the following changes to the UserCredentials grant type:

- If there is no client_id provided in the request do not fail validation immediately. Instead act like these fields were provided empty and continue.
- Log an error for missing client credentials only if public clients are not allowed.
- If a client_id is null or empty consider it a public client.