### PR TITLE
Option to return Id token on token refresh

### DIFF
--- a/src/OAuth2/Controller/TokenController.php
+++ b/src/OAuth2/Controller/TokenController.php
@@ -148,6 +148,8 @@ class TokenController implements TokenControllerInterface
             return null;
         }
 
+//        $grantTypeIdentifier = in_array('openid', explode(' ', $request->request('scope'))) ? 'refresh_token_openid' : $grantTypeIdentifier;
+
         /** @var GrantTypeInterface $grantType */
         $grantType = $this->grantTypes[$grantTypeIdentifier];
 

--- a/src/OAuth2/OpenID/GrantType/RefreshToken.php
+++ b/src/OAuth2/OpenID/GrantType/RefreshToken.php
@@ -1,0 +1,114 @@
+<?php
+
+
+namespace OAuth2\OpenID\GrantType;
+
+
+use OAuth2\Encryption\FirebaseJwt;
+use OAuth2\GrantType\RefreshToken as BaseRefreshToken;
+use OAuth2\OpenID\ResponseType\IdTokenInterface;
+use OAuth2\RequestInterface;
+use OAuth2\ResponseInterface;
+use OAuth2\ResponseType\AccessTokenInterface;
+use OAuth2\Storage\RefreshTokenInterface;
+
+/**
+ * Class RefreshToken
+ * @package OAuth2\OpenID\GrantType
+ * @author Adis Azhar <adisazhar123 at gmail dot com>
+ */
+class RefreshToken extends BaseRefreshToken
+{
+    /**
+     * @var IdTokenInterface $idToken
+     */
+    private $idToken;
+
+    public function __construct(RefreshTokenInterface $storage, IdTokenInterface $idToken, $config = array())
+    {
+        $this->idToken = $idToken;
+        parent::__construct($storage, $config);
+    }
+
+    /**
+     * Holds the refresh token
+     *
+     * @var array $refreshToken
+     */
+    private $refreshToken;
+
+    /**
+     * Validate refresh token request. This overrides method from base class
+     *
+     * @param RequestInterface $request
+     * @param ResponseInterface $response
+     * @return bool|mixed|void|null
+     * @throws \Exception
+     */
+    public function validateRequest(RequestInterface $request, ResponseInterface $response)
+    {
+        if (! in_array('openid', explode(' ', $request->request('scope')))) {
+            throw new \Exception('Refresh token request for OAuth 2.0 must not use this grant type.');
+        }
+
+        if (! $request->request('refresh_token')) {
+            $response->setError(400, 'invalid_request', 'Missing parameter: "refresh_token" is required');
+
+            return null;
+        }
+
+        if (! $refreshToken = $this->storage->getRefreshToken($request->request('refresh_token'))) {
+            $response->setError(400, 'invalid_grant', 'Invalid refresh token');
+
+            return null;
+        }
+
+        $this->refreshToken = $refreshToken;
+
+        return true;
+    }
+
+    public function createAccessToken(AccessTokenInterface $accessToken, $client_id, $user_id, $scope)
+    {
+        /*
+         * It is optional to force a new refresh token when a refresh token is used.
+         * However, if a new refresh token is issued, the old one MUST be expired
+         * @see http://tools.ietf.org/html/rfc6749#section-6
+         */
+        $issueNewRefreshToken = $this->config['always_issue_new_refresh_token'];
+        $unsetRefreshToken = $this->config['unset_refresh_token_after_use'];
+        $token = $accessToken->createAccessToken($client_id, $user_id, $scope, $issueNewRefreshToken);
+
+        if ($unsetRefreshToken) {
+            $this->storage->unsetRefreshToken($this->refreshToken['refresh_token']);
+        }
+
+        // TODO: Set configuration
+        $tempConfig = true;
+        if ($this->config['issue_id_token_on_new_refresh_token'] || $tempConfig) {
+//            $client_id, $userInfo, $nonce = null, $userClaims = null, $access_token = null
+            $jwt = new FirebaseJwt();
+            $decodedIdToken = $jwt->decode($this->refreshToken['id_token'], null, false);
+            $claims = array(
+                'iss' => $decodedIdToken['iss'],
+                'sub' => $decodedIdToken['sub'],
+                'aud' => $decodedIdToken['aud']
+            );
+
+            if (array_key_exists('auth_time', $decodedIdToken)) {
+                $authTime = array('auth_time' => $decodedIdToken['auth_time']);
+                $claims += $authTime;
+            }
+
+            if (array_key_exists('azp', $decodedIdToken)) {
+                $azp = array('azp' => $decodedIdToken['azp']);
+                $claims += $azp;
+            }
+
+            $idToken = array('id_token' => $this->idToken->createIdToken($client_id, $user_id, null, $claims, null));
+            $token += $idToken;
+        }
+
+        return $token;
+    }
+}

--- a/src/OAuth2/OpenID/GrantType/RefreshToken.php
+++ b/src/OAuth2/OpenID/GrantType/RefreshToken.php
@@ -85,7 +85,7 @@ class RefreshToken extends BaseRefreshToken
 
         // TODO: Set configuration
         $tempConfig = true;
-        if ($this->config['issue_id_token_on_new_refresh_token'] || $tempConfig) {
+        if ($this->config['issue_id_token_on_token_refresh'] || $tempConfig) {
 //            $client_id, $userInfo, $nonce = null, $userClaims = null, $access_token = null
             $jwt = new FirebaseJwt();
             $decodedIdToken = $jwt->decode($this->refreshToken['id_token'], null, false);

--- a/src/OAuth2/Server.php
+++ b/src/OAuth2/Server.php
@@ -7,6 +7,7 @@ use OAuth2\Controller\ResourceController;
 use OAuth2\OpenID\Controller\UserInfoControllerInterface;
 use OAuth2\OpenID\Controller\UserInfoController;
 use OAuth2\OpenID\Controller\AuthorizeController as OpenIDAuthorizeController;
+use OAuth2\OpenID\GrantType\RefreshToken as OpenIdRefreshTokenGrantType;
 use OAuth2\OpenID\ResponseType\AuthorizationCode as OpenIDAuthorizationCodeResponseType;
 use OAuth2\OpenID\Storage\AuthorizationCodeInterface as OpenIDAuthorizationCodeInterface;
 use OAuth2\OpenID\GrantType\AuthorizationCode as OpenIDAuthorizationCodeGrantType;
@@ -901,6 +902,11 @@ class Server implements ResourceControllerInterface,
         $authCodeGrant = $this->getGrantType('authorization_code');
         if (!empty($authCodeGrant) && !$authCodeGrant instanceof OpenIDAuthorizationCodeGrantType) {
             throw new \InvalidArgumentException('You have enabled OpenID Connect, but supplied a grant type that does not support it.');
+        }
+
+        $refreshTokenGrant = $this->getGrantType('refresh_token');
+        if (!empty($refreshTokenGrant) && !$refreshTokenGrant instanceof OpenIdRefreshTokenGrantType) {
+            throw new InvalidArgumentException('You have enabled OpenID connect, but supplied a refresh token grant type that does not support it.');
         }
     }
 

--- a/test/OAuth2/OpenID/GrantType/RefreshTokenTest.php
+++ b/test/OAuth2/OpenID/GrantType/RefreshTokenTest.php
@@ -1,0 +1,59 @@
+<?php
+
+
+namespace OAuth2\OpenID\GrantType;
+
+use OAuth2\Storage\Bootstrap;
+use OAuth2\Server;
+use OAuth2\Request\TestRequest;
+use OAuth2\Response;
+use PHPUnit\Framework\TestCase;
+
+class RefreshTokenTest extends TestCase
+{
+    private $storage;
+
+    private $serverConfig = array(
+        'use_openid_connect' => true
+    );
+
+    /**
+     * Refresh token request must have parameter 'refresh_token'
+     * @see Section 12.1 of https://openid.net/specs/openid-connect-core-1_0.html
+     */
+    public function testNoRefreshToken()
+    {
+        $server = $this->getTestServer();
+        $request = TestRequest::createPost(array(
+            'grant_type' => 'refresh_token',
+            'client_id' => 'Test Client ID',
+            'client_secret' => 'TestSecret'
+        ));
+        $server->grantAccessToken($request, $response = new Response());
+
+        $this->assertEquals($response->getStatusCode(), 400);
+        $this->assertEquals($response->getParameter('error'), 'invalid_request');
+        $this->assertEquals($response->getParameter('error_description'), 'Missing parameter: "refresh_token" is required');
+    }
+
+    public function testInvalidRefreshToken()
+    {
+        $server = $this->getTestServer();
+        $server->addGrantType(new RefreshToken($this->storage));
+
+        $request = TestRequest::createPost(array(
+            'grant_type' => 'refresh_token',
+            'client_id' => 'Test Client ID',
+            'client_secret' => 'TestSecret',
+            'refresh_token' => 'refresh_token_does_not_exist'
+        ));
+        $server->grantAccessToken($request, $response = new Response());
+    }
+
+    private function getTestServer()
+    {
+        $this->storage = Bootstrap::getInstance()->getMemoryStorage();
+
+        return new Server($this->storage, $this->serverConfig);
+    }
+}

--- a/test/config/storage.json
+++ b/test/config/storage.json
@@ -110,6 +110,14 @@
             "user_id": "test-username",
             "expires": 0,
             "scope": "scope1 scope2"
+        },
+        "test-refreshtoken-with-idtoken": {
+            "refresh_token": "test-refreshtoken-with-idtoken",
+            "client_id": "Test Client ID",
+            "user_id": "test-username",
+            "expires": 0,
+            "scope": null,
+            "id_token": "old id token"
         }
     },
     "access_tokens" : {


### PR DESCRIPTION
Answering issue #976 

I propose creating a new Refresh Token grant type under OpenID which'll allow returning ID token only if, both of these are fulfilled:
1. the configuration parameter `use_openid_connect` is set to true in Server object
2. the configuration parameter `issue_id_token_on_token_refresh` is set to true in Server object. This will be a new parameter

I'm thinking of adding a `id_token` column in table `oauth_refresh_tokens` to hold the ID token tied to that refresh token. This column will be nullable.

The code isn't done and I would like people's opinion on the approach I've taken.

Cheers,
Adis