### PR TITLE
Type hinting | Salt for hashPassword | Scope for setUser

### DIFF
--- a/src/Exception/InvalidResponseException.php
+++ b/src/Exception/InvalidResponseException.php
@@ -1,0 +1,22 @@
+<?php
+namespace OAuth2\Exception;
+
+/**
+ * Invalid Response Exception
+ */
+class InvalidResponseException extends \Exception
+{
+    // Redefine the exception so message isn't optional
+    public function __construct(string $message, int $code = 0, \Exception $previous = null) {
+        // some code
+    
+        // make sure everything is assigned properly
+        parent::__construct($message, $code, $previous);
+    }
+
+    // custom string representation of object
+    public function __toString() {
+        return __CLASS__ . ": [{$this->code}]: {$this->message}\n";
+    }
+
+}

--- a/src/Exception/NotImplementedException.php
+++ b/src/Exception/NotImplementedException.php
@@ -1,0 +1,24 @@
+<?php
+namespace OAuth2\Exception;
+
+/**
+ * Not Implemented Exception
+ * 
+ * http://php.net/manual/en/language.exceptions.extending.php
+ */
+class NotImplementedException extends \Exception
+{
+    // Redefine the exception so message isn't optional
+    public function __construct(string $message, int $code = 0, \Exception $previous = null) {
+        // some code
+    
+        // make sure everything is assigned properly
+        parent::__construct($message, $code, $previous);
+    }
+
+    // custom string representation of object
+    public function __toString() {
+        return __CLASS__ . ": [{$this->code}]: {$this->message}\n";
+    }
+
+}

--- a/src/OAuth2/GrantType/AuthorizationCode.php
+++ b/src/OAuth2/GrantType/AuthorizationCode.php
@@ -7,6 +7,7 @@ use OAuth2\ResponseType\AccessTokenInterface;
 use OAuth2\RequestInterface;
 use OAuth2\ResponseInterface;
 use Exception;
+use OAuth2\Exception\InvalidResponseException;
 
 /**
  * @author Brent Shaffer <bshafs at gmail dot com>
@@ -75,7 +76,7 @@ class AuthorizationCode implements GrantTypeInterface
         }
 
         if (!isset($authCode['expires'])) {
-            throw new \Exception('Storage must return authcode with a value for "expires"');
+            throw new InvalidResponseException('Storage must return authcode with a value for "expires"');
         }
 
         if ($authCode["expires"] < time()) {

--- a/src/OAuth2/Request.php
+++ b/src/OAuth2/Request.php
@@ -11,14 +11,14 @@ use LogicException;
  */
 class Request implements RequestInterface
 {
-    public $attributes;
-    public $request;
-    public $query;
-    public $server;
-    public $files;
-    public $cookies;
-    public $headers;
-    public $content;
+    public array $attributes;
+    public array $request;
+    public array $query;
+    public array $server;
+    public array $files;
+    public array $cookies;
+    public array $headers;
+    public string $content;
 
     /**
      * Constructor.
@@ -34,7 +34,7 @@ class Request implements RequestInterface
      *
      * @api
      */
-    public function __construct(array $query = array(), array $request = array(), array $attributes = array(), array $cookies = array(), array $files = array(), array $server = array(), $content = null, array $headers = null)
+    public function __construct(array $query = array(), array $request = array(), array $attributes = array(), array $cookies = array(), array $files = array(), array $server = array(), string $content = null, array $headers = null)
     {
         $this->initialize($query, $request, $attributes, $cookies, $files, $server, $content, $headers);
     }
@@ -55,7 +55,7 @@ class Request implements RequestInterface
      *
      * @api
      */
-    public function initialize(array $query = array(), array $request = array(), array $attributes = array(), array $cookies = array(), array $files = array(), array $server = array(), $content = null, array $headers = null)
+    public function initialize(array $query = array(), array $request = array(), array $attributes = array(), array $cookies = array(), array $files = array(), array $server = array(), string $content = null, array $headers = null)
     {
         $this->request = $request;
         $this->query = $query;
@@ -77,7 +77,7 @@ class Request implements RequestInterface
      * @param mixed  $default
      * @return mixed
      */
-    public function query($name, $default = null)
+    public function query(string $name, $default = null)
     {
         return isset($this->query[$name]) ? $this->query[$name] : $default;
     }
@@ -87,7 +87,7 @@ class Request implements RequestInterface
      * @param mixed  $default
      * @return mixed
      */
-    public function request($name, $default = null)
+    public function request(string $name, $default = null)
     {
         return isset($this->request[$name]) ? $this->request[$name] : $default;
     }
@@ -97,7 +97,7 @@ class Request implements RequestInterface
      * @param mixed  $default
      * @return mixed
      */
-    public function server($name, $default = null)
+    public function server(string $name, $default = null)
     {
         return isset($this->server[$name]) ? $this->server[$name] : $default;
     }
@@ -107,7 +107,7 @@ class Request implements RequestInterface
      * @param mixed  $default
      * @return mixed
      */
-    public function headers($name, $default = null)
+    public function headers(string $name, $default = null)
     {
         $headers = array_change_key_case($this->headers);
         $name = strtolower($name);

--- a/src/OAuth2/RequestInterface.php
+++ b/src/OAuth2/RequestInterface.php
@@ -9,31 +9,31 @@ interface RequestInterface
      * @param mixed  $default
      * @return mixed
      */
-    public function query($name, $default = null);
+    public function query(string $name, mixed $default = null);
 
     /**
      * @param string $name
      * @param mixed  $default
      * @return mixed
      */
-    public function request($name, $default = null);
+    public function request(string $name, mixed $default = null);
 
     /**
      * @param string $name
      * @param mixed  $default
      * @return mixed
      */
-    public function server($name, $default = null);
+    public function server(string $name, mixed $default = null);
 
     /**
      * @param string $name
      * @param mixed  $default
      * @return mixed
      */
-    public function headers($name, $default = null);
+    public function headers(string $name, mixed $default = null);
 
     /**
      * @return mixed
      */
-    public function getAllQueryParameters();
+    public function getAllQueryParameters(): mixed;
 }

--- a/src/OAuth2/ResponseInterface.php
+++ b/src/OAuth2/ResponseInterface.php
@@ -23,7 +23,7 @@ interface ResponseInterface
     /**
      * @param int $statusCode
      */
-    public function setStatusCode($statusCode);
+    public function setStatusCode(int $statusCode);
 
     /**
      * @param int    $statusCode
@@ -32,7 +32,7 @@ interface ResponseInterface
      * @param string $uri
      * @return mixed
      */
-    public function setError($statusCode, $name, $description = null, $uri = null);
+    public function setError(int $statusCode, string $name, string $description = null, string $uri = null): mixed;
 
     /**
      * @param int    $statusCode
@@ -43,11 +43,11 @@ interface ResponseInterface
      * @param string $errorUri
      * @return mixed
      */
-    public function setRedirect($statusCode, $url, $state = null, $error = null, $errorDescription = null, $errorUri = null);
+    public function setRedirect(int $statusCode, string $url, string $state = null, string $error = null, string $errorDescription = null, string $errorUri = null): mixed;
 
     /**
      * @param string $name
      * @return mixed
      */
-    public function getParameter($name);
+    public function getParameter(string $name): mixed;
 }

--- a/src/OAuth2/Scope.php
+++ b/src/OAuth2/Scope.php
@@ -45,7 +45,7 @@ class Scope implements ScopeInterface
      *
      * @ingroup oauth2_section_7
      */
-    public function checkScope($required_scope, $available_scope)
+    public function checkScope(string $required_scope, string $available_scope): bool
     {
         $required_scope = explode(' ', trim($required_scope));
         $available_scope = explode(' ', trim($available_scope));
@@ -59,7 +59,7 @@ class Scope implements ScopeInterface
      * @param string $scope - A space-separated string of scopes.
      * @return bool         - TRUE if it exists, FALSE otherwise.
      */
-    public function scopeExists($scope)
+    public function scopeExists(string $scope): bool
     {
         // Check reserved scopes first.
         $scope = explode(' ', trim($scope));
@@ -79,17 +79,17 @@ class Scope implements ScopeInterface
      * @param RequestInterface $request
      * @return string
      */
-    public function getScopeFromRequest(RequestInterface $request)
+    public function getScopeFromRequest(RequestInterface $request): string
     {
         // "scope" is valid if passed in either POST or QUERY
         return $request->request('scope', $request->query('scope'));
     }
 
     /**
-     * @param null $client_id
+     * @param string $client_id
      * @return mixed
      */
-    public function getDefaultScope($client_id = null)
+    public function getDefaultScope(string $client_id = null): ?string
     {
         return $this->storage->getDefaultScope($client_id);
     }

--- a/src/OAuth2/ScopeInterface.php
+++ b/src/OAuth2/ScopeInterface.php
@@ -16,14 +16,14 @@ interface ScopeInterface extends ScopeStorageInterface
      *
      * @param string $required_scope  - A space-separated string of scopes.
      * @param string $available_scope - A space-separated string of scopes.
-     * @return boolean                - TRUE if everything in required scope is contained in available scope and FALSE
+     * @return bool                - TRUE if everything in required scope is contained in available scope and FALSE
      *                                  if it isn't.
      *
      * @see http://tools.ietf.org/html/rfc6749#section-7
      *
      * @ingroup oauth2_section_7
      */
-    public function checkScope($required_scope, $available_scope);
+    public function checkScope(string $required_scope, string $available_scope): bool;
 
     /**
      * Return scope info from request
@@ -31,5 +31,5 @@ interface ScopeInterface extends ScopeStorageInterface
      * @param RequestInterface $request - Request object to check
      * @return string                   - representation of requested scope
      */
-    public function getScopeFromRequest(RequestInterface $request);
+    public function getScopeFromRequest(RequestInterface $request): string;
 }

--- a/src/OAuth2/Storage/AccessTokenInterface.php
+++ b/src/OAuth2/Storage/AccessTokenInterface.php
@@ -30,7 +30,7 @@ interface AccessTokenInterface
      *
      * @ingroup oauth2_section_7
      */
-    public function getAccessToken($oauth_token);
+    public function getAccessToken(string $oauth_token);
 
     /**
      * Store the supplied access token values to storage.
@@ -38,14 +38,14 @@ interface AccessTokenInterface
      * We need to store access token data as we create and verify tokens.
      *
      * @param string $oauth_token - oauth_token to be stored.
-     * @param mixed  $client_id   - client identifier to be stored.
-     * @param mixed  $user_id     - user identifier to be stored.
+     * @param string  $client_id   - client identifier to be stored.
+     * @param string  $user_id     - user identifier to be stored.
      * @param int    $expires     - expiration to be stored as a Unix timestamp.
      * @param string $scope       - OPTIONAL Scopes to be stored in space-separated string.
      *
      * @ingroup oauth2_section_4
      */
-    public function setAccessToken($oauth_token, $client_id, $user_id, $expires, $scope = null);
+    public function setAccessToken(string $oauth_token, string $client_id, string $user_id, $expires, ?string $scope = null);
 
     /**
      * Expire an access token.

--- a/src/OAuth2/Storage/Cassandra.php
+++ b/src/OAuth2/Storage/Cassandra.php
@@ -235,13 +235,13 @@ class Cassandra implements
      * @param string $password
      * @return bool
      */
-    protected function checkPassword($user, $password)
+    protected function checkPassword($user, $password, string $salt = ""): string
     {
-        return $user['password'] == $this->hashPassword($password);
+        return $user['password'] == $this->hashPassword($password, $salt);
     }
 
     // use a secure hashing algorithm when storing passwords. Override this for your application
-    protected function hashPassword($password)
+    protected function hashPassword($password, string $salt = ""): string
     {
         return sha1($password);
     }
@@ -278,9 +278,9 @@ class Cassandra implements
      * @param string $last_name
      * @return bool
      */
-    public function setUser($username, $password, $first_name = null, $last_name = null)
+    public function setUser($username, $password, $first_name = null, $last_name = null, string $salt = ""): bool
     {
-        $password = $this->hashPassword($password);
+        $password = $this->hashPassword($password, $salt);
 
         return $this->setValue(
             $this->config['user_key'] . $username,

--- a/src/OAuth2/Storage/ClientCredentialsInterface.php
+++ b/src/OAuth2/Storage/ClientCredentialsInterface.php
@@ -27,16 +27,16 @@ interface ClientCredentialsInterface extends ClientInterface
      *
      * @ingroup oauth2_section_3
      */
-    public function checkClientCredentials($client_id, $client_secret = null);
+    public function checkClientCredentials(string $client_id, string $client_secret = null): bool;
 
     /**
      * Determine if the client is a "public" client, and therefore
      * does not require passing credentials for certain grant types
      *
-     * @param $client_id
+     * @param string $client_id
      * Client identifier to be check with.
      *
-     * @return
+     * @return bool
      * TRUE if the client is public, and FALSE if it isn't.
      * @endcode
      *
@@ -45,5 +45,5 @@ interface ClientCredentialsInterface extends ClientInterface
      *
      * @ingroup oauth2_section_2
      */
-    public function isPublicClient($client_id);
+    public function isPublicClient(string $client_id): bool;
 }

--- a/src/OAuth2/Storage/ClientInterface.php
+++ b/src/OAuth2/Storage/ClientInterface.php
@@ -35,7 +35,7 @@ interface ClientInterface
      *
      * @ingroup oauth2_section_4
      */
-    public function getClientDetails($client_id);
+    public function getClientDetails(string $client_id): mixed;
 
     /**
      * Get the scope associated with this client
@@ -43,8 +43,7 @@ interface ClientInterface
      * @return
      * STRING the space-delineated scope list for the specified client_id
      */
-    public function getClientScope($client_id);
-
+    public function getClientScope(string $client_id = null): string;
     /**
      * Check restricted grant types of corresponding client identifier.
      *
@@ -62,5 +61,5 @@ interface ClientInterface
      *
      * @ingroup oauth2_section_4
      */
-    public function checkRestrictedGrantType($client_id, $grant_type);
+    public function checkRestrictedGrantType(string $client_id, string $grant_type): bool;
 }

--- a/src/OAuth2/Storage/CouchbaseDB.php
+++ b/src/OAuth2/Storage/CouchbaseDB.php
@@ -2,6 +2,7 @@
 
 namespace OAuth2\Storage;
 
+use OAuth2\Exception\NotImplementedException;
 use OAuth2\OpenID\Storage\AuthorizationCodeInterface as OpenIDAuthorizationCodeInterface;
 
 /**
@@ -68,7 +69,7 @@ class CouchbaseDB implements AuthorizationCodeInterface,
     }
 
     /* ClientCredentialsInterface */
-    public function checkClientCredentials($client_id, $client_secret = null)
+    public function checkClientCredentials($client_id, $client_secret = null): bool
     {
         if ($result = $this->getObjectByType('client_table',$client_id)) {
             return $result['client_secret'] == $client_secret;
@@ -77,7 +78,7 @@ class CouchbaseDB implements AuthorizationCodeInterface,
         return false;
     }
 
-    public function isPublicClient($client_id)
+    public function isPublicClient($client_id): bool
     {
         if (!$result = $this->getObjectByType('client_table',$client_id)) {
             return false;
@@ -87,7 +88,7 @@ class CouchbaseDB implements AuthorizationCodeInterface,
     }
 
     /* ClientInterface */
-    public function getClientDetails($client_id)
+    public function getClientDetails(string $client_id): mixed
     {
         $result = $this->getObjectByType('client_table',$client_id);
 
@@ -120,7 +121,7 @@ class CouchbaseDB implements AuthorizationCodeInterface,
         return true;
     }
 
-    public function checkRestrictedGrantType($client_id, $grant_type)
+    public function checkRestrictedGrantType(string $client_id, string $grant_type): bool
     {
         $details = $this->getClientDetails($client_id);
         if (isset($details['grant_types'])) {
@@ -248,7 +249,7 @@ class CouchbaseDB implements AuthorizationCodeInterface,
         return true;
     }
 
-    public function unsetRefreshToken($refresh_token)
+    public function unsetRefreshToken($refresh_token): bool
     {
         $this->deleteObjectByType('refresh_token_table',$refresh_token);
 
@@ -291,7 +292,7 @@ class CouchbaseDB implements AuthorizationCodeInterface,
         return true;
     }
 
-    public function getClientKey($client_id, $subject)
+    public function getClientKey(string $client_id, string $subject): string
     {
         if (!$jwt = $this->getObjectByType('jwt_table',$client_id)) {
             return false;
@@ -304,7 +305,7 @@ class CouchbaseDB implements AuthorizationCodeInterface,
         return false;
     }
 
-    public function getClientScope($client_id)
+    public function getClientScope(string $client_id = null): string
     {
         if (!$clientDetails = $this->getClientDetails($client_id)) {
             return false;
@@ -317,15 +318,15 @@ class CouchbaseDB implements AuthorizationCodeInterface,
         return null;
     }
 
-    public function getJti($client_id, $subject, $audience, $expiration, $jti)
+    public function getJti(string $client_id, string $subject, string $audience, string $expiration, string $jti): array
     {
         //TODO: Needs couchbase implementation.
-        throw new \Exception('getJti() for the Couchbase driver is currently unimplemented.');
+        throw new NotImplementedException('getJti() for the Couchbase driver is currently unimplemented.');
     }
 
-    public function setJti($client_id, $subject, $audience, $expiration, $jti)
+    public function setJti(string $client_id, string $subject, string $audience, string $expiration, string $jti): ?bool
     {
         //TODO: Needs couchbase implementation.
-        throw new \Exception('setJti() for the Couchbase driver is currently unimplemented.');
+        throw new NotImplementedException('setJti() for the Couchbase driver is currently unimplemented.');
     }
 }

--- a/src/OAuth2/Storage/DynamoDB.php
+++ b/src/OAuth2/Storage/DynamoDB.php
@@ -3,7 +3,7 @@
 namespace OAuth2\Storage;
 
 use Aws\DynamoDb\DynamoDbClient;
-
+use OAuth2\Exception\NotImplementedException;
 use OAuth2\OpenID\Storage\UserClaimsInterface;
 use OAuth2\OpenID\Storage\AuthorizationCodeInterface as OpenIDAuthorizationCodeInterface;
 /**
@@ -77,7 +77,7 @@ class DynamoDB implements
     }
 
     /* OAuth2\Storage\ClientCredentialsInterface */
-    public function checkClientCredentials($client_id, $client_secret = null)
+    public function checkClientCredentials(string $client_id, string $client_secret = null): bool
     {
         $result = $this->client->getItem(array(
             "TableName"=> $this->config['client_table'],
@@ -87,7 +87,7 @@ class DynamoDB implements
         return  $result->count()==1 && $result["Item"]["client_secret"]["S"] == $client_secret;
     }
 
-    public function isPublicClient($client_id)
+    public function isPublicClient(string $client_id): bool
     {
         $result = $this->client->getItem(array(
             "TableName"=> $this->config['client_table'],
@@ -102,7 +102,7 @@ class DynamoDB implements
     }
 
     /* OAuth2\Storage\ClientInterface */
-    public function getClientDetails($client_id)
+    public function getClientDetails(string $client_id): mixed
     {
         $result = $this->client->getItem(array(
             "TableName"=> $this->config['client_table'],
@@ -113,7 +113,7 @@ class DynamoDB implements
         }
         $result = $this->dynamo2array($result);
         foreach (array('client_id', 'client_secret', 'redirect_uri', 'grant_types', 'scope', 'user_id') as $key => $val) {
-            if (!array_key_exists ($val, $result)) {
+            if (!array_key_exists ($val, (array) $result)) {
                 $result[$val] = null;
             }
         }
@@ -134,7 +134,7 @@ class DynamoDB implements
         return true;
     }
 
-    public function checkRestrictedGrantType($client_id, $grant_type)
+    public function checkRestrictedGrantType(string $client_id, string $grant_type): bool
     {
         $details = $this->getClientDetails($client_id);
         if (isset($details['grant_types'])) {
@@ -148,7 +148,7 @@ class DynamoDB implements
     }
 
     /* OAuth2\Storage\AccessTokenInterface */
-    public function getAccessToken($access_token)
+    public function getAccessToken(string $access_token)
     {
         $result = $this->client->getItem(array(
             "TableName"=> $this->config['access_token_table'],
@@ -158,7 +158,7 @@ class DynamoDB implements
             return false ;
         }
         $token = $this->dynamo2array($result);
-        if (array_key_exists ('expires', $token)) {
+        if (array_key_exists ('expires', (array) $token)) {
             $token['expires'] = strtotime($token['expires']);
         }
 
@@ -204,7 +204,7 @@ class DynamoDB implements
             return false ;
         }
         $token = $this->dynamo2array($result);
-        if (!array_key_exists("id_token", $token )) {
+        if (!array_key_exists("id_token", (array) $token )) {
             $token['id_token'] = null;
         }
         $token['expires'] = strtotime($token['expires']);
@@ -330,7 +330,7 @@ class DynamoDB implements
         return true;
     }
 
-    public function unsetRefreshToken($refresh_token)
+    public function unsetRefreshToken(string $refresh_token): bool
     {
         $result = $this->client->deleteItem(array(
             'TableName' =>  $this->config['refresh_token_table'],
@@ -385,7 +385,7 @@ class DynamoDB implements
     }
 
     /* ScopeInterface */
-    public function scopeExists($scope)
+    public function scopeExists(string $scope): bool
     {
         $scope = explode(' ', $scope);
         $scope_query = array();
@@ -407,7 +407,7 @@ class DynamoDB implements
         return $count == count($scope);
     }
 
-    public function getDefaultScope($client_id = null)
+    public function getDefaultScope(string $client_id = null): string
     {
 
         $result = $this->client->query(array(
@@ -435,7 +435,7 @@ class DynamoDB implements
     }
 
     /* JWTBearerInterface */
-    public function getClientKey($client_id, $subject)
+    public function getClientKey(string $client_id, string $subject): string
     {
         $result = $this->client->getItem(array(
             "TableName"=> $this->config['jwt_table'],
@@ -449,7 +449,7 @@ class DynamoDB implements
         return $token['public_key'];
     }
 
-    public function getClientScope($client_id)
+    public function getClientScope(string $client_id = null): string
     {
         if (!$clientDetails = $this->getClientDetails($client_id)) {
             return false;
@@ -462,14 +462,16 @@ class DynamoDB implements
         return null;
     }
 
-    public function getJti($client_id, $subject, $audience, $expires, $jti)
+    public function getJti(string $client_id, string $subject, string $audience, string $expires, string $jti): array
     {
         //TODO not use.
+        throw new NotImplementedException("Method not in use");
     }
 
-    public function setJti($client_id, $subject, $audience, $expires, $jti)
+    public function setJti(string $client_id, string $subject, string $audience, string $expires, string $jti): ?bool
     {
         //TODO not use.
+        throw new NotImplementedException("Method not in use");
     }
 
     /* PublicKeyInterface */

--- a/src/OAuth2/Storage/DynamoDB.php
+++ b/src/OAuth2/Storage/DynamoDB.php
@@ -341,13 +341,13 @@ class DynamoDB implements
     }
 
     // plaintext passwords are bad!  Override this for your application
-    protected function checkPassword($user, $password)
+    protected function checkPassword($user, $password, string $salt = ""): string
     {
-        return $user['password'] == $this->hashPassword($password);
+        return $user['password'] == $this->hashPassword($password, $salt);
     }
 
     // use a secure hashing algorithm when storing passwords. Override this for your application
-    protected function hashPassword($password)
+    protected function hashPassword($password, string $salt = ""): string
     {
         return sha1($password);
     }
@@ -367,10 +367,10 @@ class DynamoDB implements
         return $token;
     }
 
-    public function setUser($username, $password, $first_name = null, $last_name = null)
+    public function setUser($username, $password, $first_name = null, $last_name = null, string $salt = ""): bool
     {
         // do not store in plaintext
-        $password = $this->hashPassword($password);
+        $password = $this->hashPassword($password, $salt);
 
         $clientData = compact('username', 'password', 'first_name', 'last_name');
         $clientData = array_filter($clientData, 'self::isNotEmpty');

--- a/src/OAuth2/Storage/JwtBearerInterface.php
+++ b/src/OAuth2/Storage/JwtBearerInterface.php
@@ -23,7 +23,7 @@ interface JwtBearerInterface
      * @return
      * STRING Return the public key for the client_id if it exists, and MUST return FALSE if it doesn't.
      */
-    public function getClientKey($client_id, $subject);
+    public function getClientKey(string $client_id, string $subject): string;
 
     /**
      * Get a jti (JSON token identifier) by matching against the client_id, subject, audience and expiration.
@@ -51,7 +51,7 @@ interface JwtBearerInterface
      * - expires: Stored expiration in unix timestamp.
      * - jti: The stored jti.
      */
-    public function getJti($client_id, $subject, $audience, $expiration, $jti);
+    public function getJti(string $client_id, string $subject, string $audience, string $expiration, string $jti): array;
 
     /**
      * Store a used jti so that we can check against it to prevent replay attacks.
@@ -70,5 +70,5 @@ interface JwtBearerInterface
      * @param $jti
      * The jti to insert.
      */
-    public function setJti($client_id, $subject, $audience, $expiration, $jti);
+    public function setJti(string $client_id, string $subject, string $audience, string $expiration, string $jti): ?bool;
 }

--- a/src/OAuth2/Storage/Memory.php
+++ b/src/OAuth2/Storage/Memory.php
@@ -164,12 +164,12 @@ class Memory implements AuthorizationCodeInterface,
     }
 
     /* ClientCredentialsInterface */
-    public function checkClientCredentials($client_id, $client_secret = null)
+    public function checkClientCredentials(string $client_id, string $client_secret = null): bool
     {
         return isset($this->clientCredentials[$client_id]['client_secret']) && $this->clientCredentials[$client_id]['client_secret'] === $client_secret;
     }
 
-    public function isPublicClient($client_id)
+    public function isPublicClient(string $client_id): bool
     {
         if (!isset($this->clientCredentials[$client_id])) {
             return false;
@@ -179,23 +179,21 @@ class Memory implements AuthorizationCodeInterface,
     }
 
     /* ClientInterface */
-    public function getClientDetails($client_id)
+    public function getClientDetails(string $client_id): mixed
     {
         if (!isset($this->clientCredentials[$client_id])) {
             return false;
         }
 
-        $clientDetails = array_merge(array(
+        return array_merge(array(
             'client_id'     => $client_id,
             'client_secret' => null,
             'redirect_uri'  => null,
             'scope'         => null,
         ), $this->clientCredentials[$client_id]);
-
-        return $clientDetails;
     }
 
-    public function checkRestrictedGrantType($client_id, $grant_type)
+    public function checkRestrictedGrantType($client_id, $grant_type): bool 
     {
         if (isset($this->clientCredentials[$client_id]['grant_types'])) {
             $grant_types = explode(' ', $this->clientCredentials[$client_id]['grant_types']);
@@ -234,7 +232,7 @@ class Memory implements AuthorizationCodeInterface,
         return true;
     }
 
-    public function unsetRefreshToken($refresh_token)
+    public function unsetRefreshToken($refresh_token): bool
     {
         if (isset($this->refreshTokens[$refresh_token])) {
             unset($this->refreshTokens[$refresh_token]);
@@ -251,7 +249,7 @@ class Memory implements AuthorizationCodeInterface,
     }
 
     /* AccessTokenInterface */
-    public function getAccessToken($access_token)
+    public function getAccessToken(string $access_token): array
     {
         return isset($this->accessTokens[$access_token]) ? $this->accessTokens[$access_token] : false;
     }
@@ -274,20 +272,20 @@ class Memory implements AuthorizationCodeInterface,
         return false;
     }
 
-    public function scopeExists($scope)
+    public function scopeExists($scope): bool 
     {
         $scope = explode(' ', trim($scope));
 
         return (count(array_diff($scope, $this->supportedScopes)) == 0);
     }
 
-    public function getDefaultScope($client_id = null)
+    public function getDefaultScope($client_id = null): string
     {
         return $this->defaultScope;
     }
 
     /*JWTBearerInterface */
-    public function getClientKey($client_id, $subject)
+    public function getClientKey(string $client_id, string $subject): string
     {
         if (isset($this->jwt[$client_id])) {
             $jwt = $this->jwt[$client_id];
@@ -301,7 +299,7 @@ class Memory implements AuthorizationCodeInterface,
         return false;
     }
 
-    public function getClientScope($client_id)
+    public function getClientScope(string $client_id = null): string
     {
         if (!$clientDetails = $this->getClientDetails($client_id)) {
             return false;
@@ -314,7 +312,7 @@ class Memory implements AuthorizationCodeInterface,
         return null;
     }
 
-    public function getJti($client_id, $subject, $audience, $expires, $jti)
+    public function getJti(string $client_id, string $subject, string $audience, string $expires, string $jti): array
     {
         foreach ($this->jti as $storedJti) {
             if ($storedJti['issuer'] == $client_id && $storedJti['subject'] == $subject && $storedJti['audience'] == $audience && $storedJti['expires'] == $expires && $storedJti['jti'] == $jti) {
@@ -331,9 +329,10 @@ class Memory implements AuthorizationCodeInterface,
         return null;
     }
 
-    public function setJti($client_id, $subject, $audience, $expires, $jti)
+    public function setJti(string $client_id, string $subject, string $audience, string $expires, string $jti): ?bool
     {
         $this->jti[] = array('issuer' => $client_id, 'subject' => $subject, 'audience' => $audience, 'expires' => $expires, 'jti' => $jti);
+        return true;
     }
 
     /*PublicKeyInterface */

--- a/src/OAuth2/Storage/Mongo.php
+++ b/src/OAuth2/Storage/Mongo.php
@@ -2,6 +2,7 @@
 
 namespace OAuth2\Storage;
 
+use OAuth2\Exception\NotImplementedException;
 use OAuth2\OpenID\Storage\AuthorizationCodeInterface as OpenIDAuthorizationCodeInterface;
 
 /**
@@ -59,7 +60,7 @@ class Mongo implements AuthorizationCodeInterface,
     }
 
     /* ClientCredentialsInterface */
-    public function checkClientCredentials($client_id, $client_secret = null)
+    public function checkClientCredentials(string $client_id, string $client_secret = null): bool
     {
         if ($result = $this->collection('client_table')->findOne(array('client_id' => $client_id))) {
             return $result['client_secret'] == $client_secret;
@@ -68,7 +69,7 @@ class Mongo implements AuthorizationCodeInterface,
         return false;
     }
 
-    public function isPublicClient($client_id)
+    public function isPublicClient(string $client_id): bool
     {
         if (!$result = $this->collection('client_table')->findOne(array('client_id' => $client_id))) {
             return false;
@@ -78,7 +79,7 @@ class Mongo implements AuthorizationCodeInterface,
     }
 
     /* ClientInterface */
-    public function getClientDetails($client_id)
+    public function getClientDetails(string $client_id): mixed
     {
         $result = $this->collection('client_table')->findOne(array('client_id' => $client_id));
 
@@ -113,7 +114,7 @@ class Mongo implements AuthorizationCodeInterface,
         return true;
     }
 
-    public function checkRestrictedGrantType($client_id, $grant_type)
+    public function checkRestrictedGrantType(string $client_id, string $grant_type): bool
     {
         $details = $this->getClientDetails($client_id);
         if (isset($details['grant_types'])) {
@@ -127,7 +128,7 @@ class Mongo implements AuthorizationCodeInterface,
     }
 
     /* AccessTokenInterface */
-    public function getAccessToken($access_token)
+    public function getAccessToken($access_token): ?string
     {
         $token = $this->collection('access_token_table')->findOne(array('access_token' => $access_token));
 
@@ -258,7 +259,7 @@ class Mongo implements AuthorizationCodeInterface,
         return true;
     }
 
-    public function unsetRefreshToken($refresh_token)
+    public function unsetRefreshToken(string $refresh_token): bool
     {
         $result = $this->collection('refresh_token_table')->remove(array(
             'refresh_token' => $refresh_token
@@ -304,7 +305,7 @@ class Mongo implements AuthorizationCodeInterface,
         return true;
     }
 
-    public function getClientKey($client_id, $subject)
+    public function getClientKey(string $client_id, string $subject): string
     {
         $result = $this->collection('jwt_table')->findOne(array(
             'client_id' => $client_id,
@@ -314,7 +315,7 @@ class Mongo implements AuthorizationCodeInterface,
         return is_null($result) ? false : $result['key'];
     }
 
-    public function getClientScope($client_id)
+    public function getClientScope(string $client_id = null): string 
     {
         if (!$clientDetails = $this->getClientDetails($client_id)) {
             return false;
@@ -327,16 +328,16 @@ class Mongo implements AuthorizationCodeInterface,
         return null;
     }
 
-    public function getJti($client_id, $subject, $audience, $expiration, $jti)
+    public function getJti(string $client_id, string $subject, string $audience, string $expires, string $jti): array
     {
         //TODO: Needs mongodb implementation.
-        throw new \Exception('getJti() for the MongoDB driver is currently unimplemented.');
+        throw new NotImplementedException('getJti() for the MongoDB driver is currently unimplemented.');
     }
 
-    public function setJti($client_id, $subject, $audience, $expiration, $jti)
+    public function setJti(string $client_id, string $subject, string $audience, string $expires, string $jti): ?bool
     {
         //TODO: Needs mongodb implementation.
-        throw new \Exception('setJti() for the MongoDB driver is currently unimplemented.');
+        throw new NotImplementedException('setJti() for the MongoDB driver is currently unimplemented.');
     }
 
     public function getPublicKey($client_id = null)

--- a/src/OAuth2/Storage/MongoDB.php
+++ b/src/OAuth2/Storage/MongoDB.php
@@ -4,6 +4,7 @@ namespace OAuth2\Storage;
 
 use MongoDB\Client;
 use MongoDB\Database;
+use OAuth2\Exception\NotImplementedException;
 use OAuth2\OpenID\Storage\AuthorizationCodeInterface as OpenIDAuthorizationCodeInterface;
 
 /**
@@ -56,7 +57,7 @@ class MongoDB implements AuthorizationCodeInterface,
     }
 
     /* ClientCredentialsInterface */
-    public function checkClientCredentials($client_id, $client_secret = null)
+    public function checkClientCredentials(string $client_id, string $client_secret = null): bool
     {
         if ($result = $this->collection('client_table')->findOne(array('client_id' => $client_id))) {
             return $result['client_secret'] == $client_secret;
@@ -64,7 +65,7 @@ class MongoDB implements AuthorizationCodeInterface,
         return false;
     }
 
-    public function isPublicClient($client_id)
+    public function isPublicClient(string $client_id): bool
     {
         if (!$result = $this->collection('client_table')->findOne(array('client_id' => $client_id))) {
             return false;
@@ -73,7 +74,7 @@ class MongoDB implements AuthorizationCodeInterface,
     }
 
     /* ClientInterface */
-    public function getClientDetails($client_id)
+    public function getClientDetails(string $client_id): mixed
     {
         $result = $this->collection('client_table')->findOne(array('client_id' => $client_id));
         return is_null($result) ? false : $result;
@@ -106,7 +107,7 @@ class MongoDB implements AuthorizationCodeInterface,
         return $result->getInsertedCount() > 0;
     }
 
-    public function checkRestrictedGrantType($client_id, $grant_type)
+    public function checkRestrictedGrantType(string $client_id, string $grant_type): bool
     {
         $details = $this->getClientDetails($client_id);
         if (isset($details['grant_types'])) {
@@ -244,7 +245,7 @@ class MongoDB implements AuthorizationCodeInterface,
         return $result->getInsertedCount() > 0;
     }
 
-    public function unsetRefreshToken($refresh_token)
+    public function unsetRefreshToken(string $refresh_token): bool
     {
         $result = $this->collection('refresh_token_table')->deleteOne(array(
             'refresh_token' => $refresh_token
@@ -289,7 +290,7 @@ class MongoDB implements AuthorizationCodeInterface,
         return $result->getInsertedCount() > 0;
     }
 
-    public function getClientKey($client_id, $subject)
+    public function getClientKey(string $client_id, string $subject): string
     {
         $result = $this->collection('jwt_table')->findOne(array(
             'client_id' => $client_id,
@@ -298,7 +299,7 @@ class MongoDB implements AuthorizationCodeInterface,
         return is_null($result) ? false : $result['key'];
     }
 
-    public function getClientScope($client_id)
+    public function getClientScope(string $client_id = null): string
     {
         if (!$clientDetails = $this->getClientDetails($client_id)) {
             return false;
@@ -309,16 +310,16 @@ class MongoDB implements AuthorizationCodeInterface,
         return null;
     }
 
-    public function getJti($client_id, $subject, $audience, $expires, $jti)
+    public function getJti(string $client_id, string $subject, string $audience, string $expiration, string $jti): array
     {
         //TODO: Needs mongodb implementation.
-        throw new \Exception('getJti() for the MongoDB driver is currently unimplemented.');
+        throw new NotImplementedException('getJti() for the MongoDB driver is currently unimplemented.');
     }
 
-    public function setJti($client_id, $subject, $audience, $expires, $jti)
+    public function setJti(string $client_id, string $subject, string $audience, string $expiration, string $jti): ?bool
     {
         //TODO: Needs mongodb implementation.
-        throw new \Exception('setJti() for the MongoDB driver is currently unimplemented.');
+        throw new NotImplementedException('setJti() for the MongoDB driver is currently unimplemented.');
     }
 
     public function getPublicKey($client_id = null)

--- a/src/OAuth2/Storage/Pdo.php
+++ b/src/OAuth2/Storage/Pdo.php
@@ -476,12 +476,12 @@ class Pdo implements
 
         // if it exists, update it.
         if ($this->getUser($username)) {
-            $stmt = $this->db->prepare(sprintf('UPDATE %s SET password=:password, first_name=:firstName, last_name=:lastName where username=:username', $this->config['user_table']));
+            $stmt = $this->db->prepare(sprintf('UPDATE %s SET password=:password, first_name=:firstName, last_name=:lastName, scope=:scope where username=:username', $this->config['user_table']));
         } else {
-            $stmt = $this->db->prepare(sprintf('INSERT INTO %s (username, password, first_name, last_name) VALUES (:username, :password, :firstName, :lastName)', $this->config['user_table']));
+            $stmt = $this->db->prepare(sprintf('INSERT INTO %s (username, password, first_name, last_name, scope) VALUES (:username, :password, :firstName, :lastName, :scope)', $this->config['user_table']));
         }
 
-        return $stmt->execute(compact('username', 'password', 'firstName', 'lastName'));
+        return $stmt->execute(compact('username', 'password', 'firstName', 'lastName', 'scope'));
     }
 
     /**

--- a/src/OAuth2/Storage/Pdo.php
+++ b/src/OAuth2/Storage/Pdo.php
@@ -430,13 +430,13 @@ class Pdo implements
      * @param string $password
      * @return bool
      */
-    protected function checkPassword(array $user, string  $password)
+    protected function checkPassword(array $user, string  $password, string $salt = ""): string
     {
-        return $user['password'] == $this->hashPassword($password);
+        return $user['password'] == $this->hashPassword($password, $salt);
     }
 
     // use a secure hashing algorithm when storing passwords. Override this for your application
-    protected function hashPassword(string $password)
+    protected function hashPassword(string $password, string $salt = ""): string
     {
         return sha1($password);
     }
@@ -469,10 +469,10 @@ class Pdo implements
      * @param string $lastName
      * @return bool
      */
-    public function setUser(string $username, string $password, string $firstName = null, string $lastName = null): bool
+    public function setUser(string $username, string $password, string $firstName = null, string $lastName = null, string $salt = ""): bool
     {
         // do not store in plaintext
-        $password = $this->hashPassword($password);
+        $password = $this->hashPassword($password, $salt);
 
         // if it exists, update it.
         if ($this->getUser($username)) {

--- a/src/OAuth2/Storage/PublicKeyInterface.php
+++ b/src/OAuth2/Storage/PublicKeyInterface.php
@@ -14,17 +14,17 @@ interface PublicKeyInterface
      * @param mixed $client_id
      * @return mixed
      */
-    public function getPublicKey($client_id = null);
+    public function getPublicKey(string $client_id = null): mixed;
 
     /**
      * @param mixed $client_id
      * @return mixed
      */
-    public function getPrivateKey($client_id = null);
+    public function getPrivateKey(string $client_id = null): mixed;
 
     /**
      * @param mixed $client_id
      * @return mixed
      */
-    public function getEncryptionAlgorithm($client_id = null);
+    public function getEncryptionAlgorithm(string $client_id = null): mixed;
 }

--- a/src/OAuth2/Storage/RefreshTokenInterface.php
+++ b/src/OAuth2/Storage/RefreshTokenInterface.php
@@ -34,7 +34,7 @@ interface RefreshTokenInterface
      *
      * @ingroup oauth2_section_6
      */
-    public function getRefreshToken($refresh_token);
+    public function getRefreshToken(string $refresh_token);
 
     /**
      * Take the provided refresh token values and store them somewhere.
@@ -60,7 +60,7 @@ interface RefreshTokenInterface
      *
      * @ingroup oauth2_section_6
      */
-    public function setRefreshToken($refresh_token, $client_id, $user_id, $expires, $scope = null);
+    public function setRefreshToken(string $refresh_token, string $client_id, string $user_id, string $expires, string $scope = null);
 
     /**
      * Expire a used refresh token.
@@ -78,5 +78,5 @@ interface RefreshTokenInterface
      *
      * @ingroup oauth2_section_6
      */
-    public function unsetRefreshToken($refresh_token);
+    public function unsetRefreshToken(string $refresh_token): bool;
 }

--- a/src/OAuth2/Storage/ScopeInterface.php
+++ b/src/OAuth2/Storage/ScopeInterface.php
@@ -20,7 +20,7 @@ interface ScopeInterface
      * @return
      * TRUE if it exists, FALSE otherwise.
      */
-    public function scopeExists($scope);
+    public function scopeExists(string $scope): bool;
 
     /**
      * The default scope to use in the event the client
@@ -42,5 +42,5 @@ interface ScopeInterface
      * ex:
      *     null
      */
-    public function getDefaultScope($client_id = null);
+    public function getDefaultScope(string $client_id = null): ?string;
 }

--- a/src/OAuth2/Storage/UserCredentialsInterface.php
+++ b/src/OAuth2/Storage/UserCredentialsInterface.php
@@ -34,7 +34,7 @@ interface UserCredentialsInterface
      *
      * @ingroup oauth2_section_4
      */
-    public function checkUserCredentials($username, $password);
+    public function checkUserCredentials(string $username, string $password);
 
     /**
      * @param string $username - username to get details for
@@ -48,5 +48,5 @@ interface UserCredentialsInterface
      *     );
      * @endcode
      */
-    public function getUserDetails($username);
+    public function getUserDetails(string $username);
 }

--- a/src/OAuth2/TokenType/Mac.php
+++ b/src/OAuth2/TokenType/Mac.php
@@ -10,12 +10,12 @@ use OAuth2\ResponseInterface;
 */
 class Mac implements TokenTypeInterface
 {
-    public function getTokenType()
+    public function getTokenType(): string
     {
         return 'mac';
     }
 
-    public function getAccessTokenParameter(RequestInterface $request, ResponseInterface $response)
+    public function getAccessTokenParameter(RequestInterface $request, ResponseInterface $response): string
     {
         throw new \LogicException("Not supported");
     }

--- a/src/OAuth2/TokenType/TokenTypeInterface.php
+++ b/src/OAuth2/TokenType/TokenTypeInterface.php
@@ -12,10 +12,10 @@ interface TokenTypeInterface
      *
      * ex: "bearer" or "mac"
      */
-    public function getTokenType();
+    public function getTokenType(): string;
 
     /**
      * Retrieves the token string from the request object
      */
-    public function getAccessTokenParameter(RequestInterface $request, ResponseInterface $response);
+    public function getAccessTokenParameter(RequestInterface $request, ResponseInterface $response): string;
 }


### PR DESCRIPTION
Added Salt parameter to hashPassword() and all functions calling it in all implementations. allows for using salts and therefore more safe hashing algorithms.

Added Type hinting to most functions

Fixed return types for some that were not completely aligned

Added two Exceptions to clearly state that functions are not implemented.

Added scope  to Pdo::setUser so that scope can be set immediately when creating a user