### PR TITLE
adjust type hint for Symfony 6

### DIFF
--- a/src/OAuth2/Response.php
+++ b/src/OAuth2/Response.php
@@ -140,11 +140,10 @@ class Response implements ResponseInterface
     }
 
     /**
-     * @param int $statusCode
      * @param string $text
      * @throws InvalidArgumentException
      */
-    public function setStatusCode($statusCode, $text = null)
+    public function setStatusCode(int $statusCode, $text = null)
     {
         $this->statusCode = (int) $statusCode;
         if ($this->isInvalid()) {

--- a/src/OAuth2/ResponseInterface.php
+++ b/src/OAuth2/ResponseInterface.php
@@ -20,10 +20,7 @@ interface ResponseInterface
      */
     public function addHttpHeaders(array $httpHeaders);
 
-    /**
-     * @param int $statusCode
-     */
-    public function setStatusCode($statusCode);
+    public function setStatusCode(int $statusCode);
 
     /**
      * @param int    $statusCode


### PR DESCRIPTION
related to https://github.com/bshaffer/oauth2-server-httpfoundation-bridge/pull/42

fixes the following errors:

```
Declaration of OAuth2\HttpFoundationBridge\Response::setStatusCode(int $statusCode, ?string $text = null): static must be compatible with OAuth2\ResponseInterface::setStatusCode($statusCode)
public function setStatusCode(int $statusCode); in ResponseInterface and OAuth\Response.php 
```