### PR TITLE
pick up nonce correctly in authorize endpoint since it could be a POST request as well

### DIFF
--- a/src/OAuth2/OpenID/Controller/AuthorizeController.php
+++ b/src/OAuth2/OpenID/Controller/AuthorizeController.php
@@ -79,7 +79,7 @@ class AuthorizeController extends BaseAuthorizeController implements AuthorizeCo
             return false;
         }
 
-        $nonce = $request->query('nonce');
+        $nonce = $request->request('nonce');
 
         // Validate required nonce for "id_token" and "id_token token"
         if (!$nonce && in_array($this->getResponseType(), array(self::RESPONSE_TYPE_ID_TOKEN, self::RESPONSE_TYPE_ID_TOKEN_TOKEN))) {

--- a/src/OAuth2/OpenID/Controller/AuthorizeController.php
+++ b/src/OAuth2/OpenID/Controller/AuthorizeController.php
@@ -79,7 +79,7 @@ class AuthorizeController extends BaseAuthorizeController implements AuthorizeCo
             return false;
         }
 
-        $nonce = $request->request('nonce');
+        $nonce = $request->query('nonce', $request->request('nonce'));
 
         // Validate required nonce for "id_token" and "id_token token"
         if (!$nonce && in_array($this->getResponseType(), array(self::RESPONSE_TYPE_ID_TOKEN, self::RESPONSE_TYPE_ID_TOKEN_TOKEN))) {


### PR DESCRIPTION
This PR fixes the issue of missing `nonce` in `id_token` when it's set by the oauth client while hitting the Authorize Endpoint when POST request is used, breaking OIDC compliance.

[OIDC Spec](https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint) specifies both GET and POST are supported for Authorize Endpoint.

Fixes #768 which highlights the same issue