### PR TITLE
Add support for xml request , to add xml request into Request object

### DIFF
--- a/src/OAuth2/Request.php
+++ b/src/OAuth2/Request.php
@@ -245,6 +245,15 @@ class Request implements RequestInterface
         ) {
             $data = json_decode($request->getContent(), true);
             $request->request = $data;
+        } elseif (
+            0 === strpos($contentType, 'application/xml')
+            && in_array(strtoupper($requestMethod), array('POST', 'PUT', 'DELETE'))
+        ) {
+            $data = json_decode(
+                json_encode(simplexml_load_string($request->getContent())),
+                true
+            );
+            $request->request = $data;
         }
 
         return $request;


### PR DESCRIPTION
While working with XML Request when I pass the request as XML from postman. 
The lib Request class unable to read the Request parameters. After adding these changes I was able to continue. 