### PR TITLE
PHP 8.1 fix for ctype_digit() deprecated error

### DIFF
--- a/src/OAuth2/GrantType/JwtBearer.php
+++ b/src/OAuth2/GrantType/JwtBearer.php
@@ -127,7 +127,7 @@ class JwtBearer implements GrantTypeInterface, ClientAssertionTypeInterface
         }
 
         // Check expiration
-        if (ctype_digit($jwt['exp'])) {
+        if (ctype_digit((string)$jwt['exp'])) {
             if ($jwt['exp'] <= time()) {
                 $response->setError(400, 'invalid_grant', "JWT has expired");
 
@@ -141,7 +141,7 @@ class JwtBearer implements GrantTypeInterface, ClientAssertionTypeInterface
 
         // Check the not before time
         if ($notBefore = $jwt['nbf']) {
-            if (ctype_digit($notBefore)) {
+            if (ctype_digit((string)$notBefore)) {
                 if ($notBefore > time()) {
                     $response->setError(400, 'invalid_grant', "JWT cannot be used before the Not Before (nbf) time");
 


### PR DESCRIPTION
Fix for PHP 8.1 deprecated error: ctype_digit(): Argument of type int will be interpreted as string in the future in `bshaffer/oauth2-server-php/src/OAuth2/GrantType/JwtBearer.php`

see https://www.php.net/manual/en/function.ctype-digit.php