### PR TITLE
Add support of PKCE

### DIFF
--- a/src/OAuth2/Controller/AuthorizeController.php
+++ b/src/OAuth2/Controller/AuthorizeController.php
@@ -87,6 +87,7 @@ class AuthorizeController implements AuthorizeControllerInterface
             'enforce_state'  => true,
             'require_exact_redirect_uri' => true,
             'redirect_status_code' => 302,
+            'enforce_pkce' => false,
         ), $config);
 
         if (is_null($scopeUtil)) {

--- a/src/OAuth2/GrantType/AuthorizationCode.php
+++ b/src/OAuth2/GrantType/AuthorizationCode.php
@@ -84,7 +84,6 @@ class AuthorizationCode implements GrantTypeInterface
             return false;
         }
 
-        // @TODO: Should we enforce presence of a non-falsy code challenge?
         if (isset($authCode['code_challenge']) && $authCode['code_challenge']) {
           if (!($code_verifier = $request->request('code_verifier'))) {
             $response->setError(400, 'code_verifier_missing', "The PKCE code verifier parameter is required.");

--- a/src/OAuth2/GrantType/AuthorizationCode.php
+++ b/src/OAuth2/GrantType/AuthorizationCode.php
@@ -85,41 +85,38 @@ class AuthorizationCode implements GrantTypeInterface
         }
 
         if (isset($authCode['code_challenge']) && $authCode['code_challenge']) {
-          if (!($code_verifier = $request->request('code_verifier'))) {
-            $response->setError(400, 'code_verifier_missing', "The PKCE code verifier parameter is required.");
+            if (!($code_verifier = $request->request('code_verifier'))) {
+                $response->setError(400, 'code_verifier_missing', "The PKCE code verifier parameter is required.");
 
-            return false;
-          }
-          // Validate code_verifier according to RFC-7636
-          // @see: https://tools.ietf.org/html/rfc7636#section-4.1
-          elseif (preg_match('/^[A-Za-z0-9-._~]{43,128}$/', $code_verifier) !== 1) {
-            $response->setError(400, 'code_verifier_invalid', "The PKCE code verifier parameter is invalid.");
+                return false;
+            }
+            // Validate code_verifier according to RFC-7636
+            // @see: https://tools.ietf.org/html/rfc7636#section-4.1
+            if (preg_match('/^[A-Za-z0-9-._~]{43,128}$/', $code_verifier) !== 1) {
+                $response->setError(400, 'code_verifier_invalid', "The PKCE code verifier parameter is invalid.");
 
-            return false;
-          }
-          else {
+                return false;
+            }
             $code_verifier = $request->request('code_verifier');
             switch ($authCode['code_challenge_method']) {
-              case 'S256':
-                $code_verifier_hashed = strtr(rtrim(base64_encode(hash('sha256', $code_verifier, true)), '='), '+/', '-_');
-                break;
+                case 'S256':
+                    $code_verifier_hashed = strtr(rtrim(base64_encode(hash('sha256', $code_verifier, true)), '='), '+/', '-_');
+                    break;
 
-              case 'plain':
-                $code_verifier_hashed = $code_verifier;
-                break;
+                case 'plain':
+                    $code_verifier_hashed = $code_verifier;
+                    break;
 
-              default:
-                $response->setError(400, 'code_challenge_method_invalid', "Unknown PKCE code challenge method.");
+                default:
+                    $response->setError(400, 'code_challenge_method_invalid', "Unknown PKCE code challenge method.");
 
                 return FALSE;
             }
-            // @TODO: use hash_equals in recent versions of PHP.
             if ($code_verifier_hashed !== $authCode['code_challenge']) {
-              $response->setError(400, 'code_verifier_mismatch', "The PKCE code verifier parameter does not match the code challenge.");
+                $response->setError(400, 'code_verifier_mismatch', "The PKCE code verifier parameter does not match the code challenge.");
 
-              return FALSE;
+                return FALSE;
             }
-          }
         }
 
         if (!isset($authCode['code'])) {

--- a/src/OAuth2/OpenID/Controller/AuthorizeController.php
+++ b/src/OAuth2/OpenID/Controller/AuthorizeController.php
@@ -107,16 +107,24 @@ class AuthorizeController extends BaseAuthorizeController implements AuthorizeCo
         $code_challenge = $request->query('code_challenge');
         $code_challenge_method = $request->query('code_challenge_method');
 
-        if (!$code_challenge && $this->config['enforce_pkce']) {
-            $response->setError(400, 'missing_code_challenge', 'This application requires you specify provide a PKCE code challenge');
+        if ($this->config['enforce_pkce']) {
+            if (!$code_challenge) {
+                $response->setError(400, 'missing_code_challenge', 'This application requires you provide a PKCE code challenge');
+
+                return false;
+            }
+
+            if (preg_match('/^[A-Za-z0-9-._~]{43,128}$/', $code_challenge) !== 1) {
+            $response->setError(400, 'invalid_code_challenge', 'The PKCE code challenge supplied is invalid');
 
             return false;
-        }
+          }
 
-        if (!in_array($code_challenge_method, array('plain', 'S256'), TRUE) && $this->config['enforce_pkce']) {
-            $response->setError(400, 'missing_code_challenge_method', 'This application requires you specify provide a PKCE code challenge method');
+            if (!in_array($code_challenge_method, array('plain', 'S256'), true)) {
+                $response->setError(400, 'missing_code_challenge_method', 'This application requires you specify a PKCE code challenge method');
 
-            return false;
+                return false;
+            }
         }
 
         $this->code_challenge = $code_challenge;

--- a/src/OAuth2/OpenID/ResponseType/AuthorizationCode.php
+++ b/src/OAuth2/OpenID/ResponseType/AuthorizationCode.php
@@ -31,9 +31,9 @@ class AuthorizationCode extends BaseAuthorizationCode implements AuthorizationCo
         // build the URL to redirect to
         $result = array('query' => array());
 
-        $params += array('scope' => null, 'state' => null, 'id_token' => null);
+        $params += array('scope' => null, 'state' => null, 'id_token' => null, 'code_challenge' => null, 'code_challenge_method' => null);
 
-        $result['query']['code'] = $this->createAuthorizationCode($params['client_id'], $user_id, $params['redirect_uri'], $params['scope'], $params['id_token']);
+        $result['query']['code'] = $this->createAuthorizationCode($params['client_id'], $user_id, $params['redirect_uri'], $params['scope'], $params['id_token'], $params['code_challenge'], $params['code_challenge_method']);
 
         if (isset($params['state'])) {
             $result['query']['state'] = $params['state'];
@@ -56,10 +56,10 @@ class AuthorizationCode extends BaseAuthorizationCode implements AuthorizationCo
      * @see http://tools.ietf.org/html/rfc6749#section-4
      * @ingroup oauth2_section_4
      */
-    public function createAuthorizationCode($client_id, $user_id, $redirect_uri, $scope = null, $id_token = null)
+    public function createAuthorizationCode($client_id, $user_id, $redirect_uri, $scope = null, $id_token = null, $code_challenge = null, $code_challenge_method = null)
     {
         $code = $this->generateAuthorizationCode();
-        $this->storage->setAuthorizationCode($code, $client_id, $user_id, $redirect_uri, time() + $this->config['auth_code_lifetime'], $scope, $id_token);
+        $this->storage->setAuthorizationCode($code, $client_id, $user_id, $redirect_uri, time() + $this->config['auth_code_lifetime'], $scope, $id_token, $code_challenge, $code_challenge_method);
 
         return $code;
     }

--- a/src/OAuth2/OpenID/Storage/AuthorizationCodeInterface.php
+++ b/src/OAuth2/OpenID/Storage/AuthorizationCodeInterface.php
@@ -33,5 +33,5 @@ interface AuthorizationCodeInterface extends BaseAuthorizationCodeInterface
      *
      * @ingroup oauth2_section_4
      */
-    public function setAuthorizationCode($code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null);
+    public function setAuthorizationCode($code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null, $code_challenge = null, $code_challenge_method = null);
 }

--- a/src/OAuth2/ResponseType/AuthorizationCode.php
+++ b/src/OAuth2/ResponseType/AuthorizationCode.php
@@ -26,9 +26,9 @@ class AuthorizationCode implements AuthorizationCodeInterface
         // build the URL to redirect to
         $result = array('query' => array());
 
-        $params += array('scope' => null, 'state' => null);
+        $params += array('scope' => null, 'state' => null, 'code_challenge' => null, 'code_challenge_method' => null);
 
-        $result['query']['code'] = $this->createAuthorizationCode($params['client_id'], $user_id, $params['redirect_uri'], $params['scope']);
+        $result['query']['code'] = $this->createAuthorizationCode($params['client_id'], $user_id, $params['redirect_uri'], $params['scope'], $params['code_challenge'], $params['code_challenge_method']);
 
         if (isset($params['state'])) {
             $result['query']['state'] = $params['state'];
@@ -53,10 +53,10 @@ class AuthorizationCode implements AuthorizationCodeInterface
      * @see http://tools.ietf.org/html/rfc6749#section-4
      * @ingroup oauth2_section_4
      */
-    public function createAuthorizationCode($client_id, $user_id, $redirect_uri, $scope = null)
+    public function createAuthorizationCode($client_id, $user_id, $redirect_uri, $scope = null, $code_challenge = null, $code_challenge_method = null)
     {
         $code = $this->generateAuthorizationCode();
-        $this->storage->setAuthorizationCode($code, $client_id, $user_id, $redirect_uri, time() + $this->config['auth_code_lifetime'], $scope);
+        $this->storage->setAuthorizationCode($code, $client_id, $user_id, $redirect_uri, time() + $this->config['auth_code_lifetime'], $scope, $code_challenge, $code_challenge_method);
 
         return $code;
     }

--- a/src/OAuth2/Server.php
+++ b/src/OAuth2/Server.php
@@ -172,6 +172,7 @@ class Server implements ResourceControllerInterface,
             'enforce_state'            => true,
             'require_exact_redirect_uri' => true,
             'allow_implicit'           => false,
+            'enforce_pkce'             => false,
             'allow_credentials_in_request_body' => true,
             'allow_public_clients'     => true,
             'always_issue_new_refresh_token' => false,
@@ -577,7 +578,7 @@ class Server implements ResourceControllerInterface,
             }
         }
 
-        $config = array_intersect_key($this->config, array_flip(explode(' ', 'allow_implicit enforce_state require_exact_redirect_uri')));
+        $config = array_intersect_key($this->config, array_flip(explode(' ', 'allow_implicit enforce_state require_exact_redirect_uri enforce_pkce')));
 
         if ($this->config['use_openid_connect']) {
             return new OpenIDAuthorizeController($this->storages['client'], $this->responseTypes, $config, $this->getScopeUtil());

--- a/src/OAuth2/Storage/Cassandra.php
+++ b/src/OAuth2/Storage/Cassandra.php
@@ -191,11 +191,11 @@ class Cassandra implements AuthorizationCodeInterface,
      * @param string $id_token
      * @return bool
      */
-    public function setAuthorizationCode($authorization_code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null)
+    public function setAuthorizationCode($authorization_code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null, $code_challenge = null, $code_challenge_method = null)
     {
         return $this->setValue(
             $this->config['code_key'] . $authorization_code,
-            compact('authorization_code', 'client_id', 'user_id', 'redirect_uri', 'expires', 'scope', 'id_token'),
+            compact('authorization_code', 'client_id', 'user_id', 'redirect_uri', 'expires', 'scope', 'id_token', 'code_challenge', 'code_challenge_method'),
             $expires
         );
     }

--- a/src/OAuth2/Storage/CouchbaseDB.php
+++ b/src/OAuth2/Storage/CouchbaseDB.php
@@ -173,7 +173,7 @@ class CouchbaseDB implements AuthorizationCodeInterface,
         return is_null($code) ? false : $code;
     }
 
-    public function setAuthorizationCode($code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null)
+    public function setAuthorizationCode($code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null, $code_challenge = null, $code_challenge_method = null)
     {
         // if it exists, update it.
         if ($this->getAuthorizationCode($code)) {
@@ -185,6 +185,8 @@ class CouchbaseDB implements AuthorizationCodeInterface,
                 'expires' => $expires,
                 'scope' => $scope,
                 'id_token' => $id_token,
+                'code_challenge' => $code_challenge,
+                'code_challenge_method' => $code_challenge_method,
             ));
         } else {
             $this->setObjectByType('code_table',$code,array(
@@ -195,6 +197,8 @@ class CouchbaseDB implements AuthorizationCodeInterface,
                 'expires' => $expires,
                 'scope' => $scope,
                 'id_token' => $id_token,
+                'code_challenge' => $code_challenge,
+                'code_challenge_method' => $code_challenge_method,
             ));
         }
 

--- a/src/OAuth2/Storage/DynamoDB.php
+++ b/src/OAuth2/Storage/DynamoDB.php
@@ -213,12 +213,12 @@ class DynamoDB implements
 
     }
 
-    public function setAuthorizationCode($authorization_code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null)
+    public function setAuthorizationCode($authorization_code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null, $code_challenge = null, $code_challenge_method = null)
     {
         // convert expires to datestring
         $expires = date('Y-m-d H:i:s', $expires);
 
-        $clientData = compact('authorization_code', 'client_id', 'user_id', 'redirect_uri', 'expires', 'id_token', 'scope');
+        $clientData = compact('authorization_code', 'client_id', 'user_id', 'redirect_uri', 'expires', 'scope', 'id_token', 'code_challenge', 'code_challenge_method');
         $clientData = array_filter($clientData, 'self::isNotEmpty');
 
         $result = $this->client->putItem(array(

--- a/src/OAuth2/Storage/Memory.php
+++ b/src/OAuth2/Storage/Memory.php
@@ -74,9 +74,9 @@ class Memory implements AuthorizationCodeInterface,
         ), $this->authorizationCodes[$code]);
     }
 
-    public function setAuthorizationCode($code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null)
+    public function setAuthorizationCode($code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null, $code_challenge = null, $code_challenge_method = null)
     {
-        $this->authorizationCodes[$code] = compact('code', 'client_id', 'user_id', 'redirect_uri', 'expires', 'scope', 'id_token');
+        $this->authorizationCodes[$code] = compact('code', 'client_id', 'user_id', 'redirect_uri', 'expires', 'scope', 'id_token', 'code_challenge', 'code_challenge_method');
 
         return true;
     }

--- a/src/OAuth2/Storage/Mongo.php
+++ b/src/OAuth2/Storage/Mongo.php
@@ -179,7 +179,7 @@ class Mongo implements AuthorizationCodeInterface,
         return is_null($code) ? false : $code;
     }
 
-    public function setAuthorizationCode($code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null)
+    public function setAuthorizationCode($code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null, $code_challenge = null, $code_challenge_method = null)
     {
         // if it exists, update it.
         if ($this->getAuthorizationCode($code)) {
@@ -192,6 +192,8 @@ class Mongo implements AuthorizationCodeInterface,
                     'expires' => $expires,
                     'scope' => $scope,
                     'id_token' => $id_token,
+                    'code_challenge' => $code_challenge,
+                    'code_challenge_method' => $code_challenge_method,
                 ))
             );
         } else {
@@ -203,6 +205,8 @@ class Mongo implements AuthorizationCodeInterface,
                 'expires' => $expires,
                 'scope' => $scope,
                 'id_token' => $id_token,
+                'code_challenge' => $code_challenge,
+                'code_challenge_method' => $code_challenge_method,
             );
             $this->collection('code_table')->insert($token);
         }

--- a/src/OAuth2/Storage/MongoDB.php
+++ b/src/OAuth2/Storage/MongoDB.php
@@ -167,7 +167,7 @@ class MongoDB implements AuthorizationCodeInterface,
         return is_null($code) ? false : $code;
     }
 
-    public function setAuthorizationCode($code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null)
+    public function setAuthorizationCode($code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null, $code_challenge = null, $code_challenge_method = null)
     {
         // if it exists, update it.
         if ($this->getAuthorizationCode($code)) {
@@ -180,6 +180,8 @@ class MongoDB implements AuthorizationCodeInterface,
                     'expires' => $expires,
                     'scope' => $scope,
                     'id_token' => $id_token,
+                    'code_challenge' => $code_challenge,
+                    'code_challenge_method' => $code_challenge_method,
                 ))
             );
             return $result->getMatchedCount() > 0;
@@ -192,6 +194,8 @@ class MongoDB implements AuthorizationCodeInterface,
             'expires' => $expires,
             'scope' => $scope,
             'id_token' => $id_token,
+            'code_challenge' => $code_challenge,
+            'code_challenge_method' => $code_challenge_method,
         );
         $result = $this->collection('code_table')->insertOne($token);
         return $result->getInsertedCount() > 0;

--- a/src/OAuth2/Storage/Pdo.php
+++ b/src/OAuth2/Storage/Pdo.php
@@ -247,9 +247,9 @@ class Pdo implements
      * @param string $id_token
      * @return bool|mixed
      */
-    public function setAuthorizationCode($code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null)
+    public function setAuthorizationCode($code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null, $code_challenge = null, $code_challenge_method = null)
     {
-        if (func_num_args() > 6) {
+        if ($id_token) {
             // we are calling with an id token
             return call_user_func_array(array($this, 'setAuthorizationCodeWithIdToken'), func_get_args());
         }
@@ -259,12 +259,12 @@ class Pdo implements
 
         // if it exists, update it.
         if ($this->getAuthorizationCode($code)) {
-            $stmt = $this->db->prepare($sql = sprintf('UPDATE %s SET client_id=:client_id, user_id=:user_id, redirect_uri=:redirect_uri, expires=:expires, scope=:scope where authorization_code=:code', $this->config['code_table']));
+            $stmt = $this->db->prepare($sql = sprintf('UPDATE %s SET client_id=:client_id, user_id=:user_id, redirect_uri=:redirect_uri, expires=:expires, scope=:scope, code_challenge=:code_challenge, code_challenge_method=:code_challenge_method where authorization_code=:code', $this->config['code_table']));
         } else {
-            $stmt = $this->db->prepare(sprintf('INSERT INTO %s (authorization_code, client_id, user_id, redirect_uri, expires, scope) VALUES (:code, :client_id, :user_id, :redirect_uri, :expires, :scope)', $this->config['code_table']));
+            $stmt = $this->db->prepare(sprintf('INSERT INTO %s (authorization_code, client_id, user_id, redirect_uri, expires, scope, code_challenge, code_challenge_method) VALUES (:code, :client_id, :user_id, :redirect_uri, :expires, :scope, :code_challenge, :code_challenge_method)', $this->config['code_table']));
         }
 
-        return $stmt->execute(compact('code', 'client_id', 'user_id', 'redirect_uri', 'expires', 'scope'));
+        return $stmt->execute(compact('code', 'client_id', 'user_id', 'redirect_uri', 'expires', 'scope', 'code_challenge', 'code_challenge_method'));
     }
 
     /**
@@ -277,19 +277,19 @@ class Pdo implements
      * @param string $id_token
      * @return bool
      */
-    private function setAuthorizationCodeWithIdToken($code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null)
+    private function setAuthorizationCodeWithIdToken($code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null, $code_challenge = null, $code_challenge_method = null)
     {
         // convert expires to datestring
         $expires = date('Y-m-d H:i:s', $expires);
 
         // if it exists, update it.
         if ($this->getAuthorizationCode($code)) {
-            $stmt = $this->db->prepare($sql = sprintf('UPDATE %s SET client_id=:client_id, user_id=:user_id, redirect_uri=:redirect_uri, expires=:expires, scope=:scope, id_token =:id_token where authorization_code=:code', $this->config['code_table']));
+            $stmt = $this->db->prepare($sql = sprintf('UPDATE %s SET client_id=:client_id, user_id=:user_id, redirect_uri=:redirect_uri, expires=:expires, scope=:scope, id_token =:id_token, code_challenge=:code_challenge, code_challenge_method=:code_challenge_method where authorization_code=:code', $this->config['code_table']));
         } else {
-            $stmt = $this->db->prepare(sprintf('INSERT INTO %s (authorization_code, client_id, user_id, redirect_uri, expires, scope, id_token) VALUES (:code, :client_id, :user_id, :redirect_uri, :expires, :scope, :id_token)', $this->config['code_table']));
+            $stmt = $this->db->prepare(sprintf('INSERT INTO %s (authorization_code, client_id, user_id, redirect_uri, expires, scope, id_token, code_challenge, code_challenge_method) VALUES (:code, :client_id, :user_id, :redirect_uri, :expires, :scope, :id_token, :code_challenge, :code_challenge_method)', $this->config['code_table']));
         }
 
-        return $stmt->execute(compact('code', 'client_id', 'user_id', 'redirect_uri', 'expires', 'scope', 'id_token'));
+        return $stmt->execute(compact('code', 'client_id', 'user_id', 'redirect_uri', 'expires', 'scope', 'id_token', 'code_challenge', 'code_challenge_method'));
     }
 
     /**
@@ -676,6 +676,8 @@ class Pdo implements
               expires             TIMESTAMP      NOT NULL,
               scope               VARCHAR(4000),
               id_token            VARCHAR(1000),
+              code_challenge        VARCHAR(1000),
+              code_challenge_method VARCHAR(20),
               PRIMARY KEY (authorization_code)
             );
 

--- a/src/OAuth2/Storage/Pdo.php
+++ b/src/OAuth2/Storage/Pdo.php
@@ -249,7 +249,7 @@ class Pdo implements
      */
     public function setAuthorizationCode($code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null, $code_challenge = null, $code_challenge_method = null)
     {
-        if ($id_token) {
+        if (func_num_args() > 6) {
             // we are calling with an id token
             return call_user_func_array(array($this, 'setAuthorizationCodeWithIdToken'), func_get_args());
         }

--- a/src/OAuth2/Storage/Redis.php
+++ b/src/OAuth2/Storage/Redis.php
@@ -95,11 +95,11 @@ class Redis implements AuthorizationCodeInterface,
         return $this->getValue($this->config['code_key'] . $code);
     }
 
-    public function setAuthorizationCode($authorization_code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null)
+    public function setAuthorizationCode($authorization_code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null, $code_challenge = null, $code_challenge_method = null)
     {
         return $this->setValue(
             $this->config['code_key'] . $authorization_code,
-            compact('authorization_code', 'client_id', 'user_id', 'redirect_uri', 'expires', 'scope', 'id_token'),
+            compact('authorization_code', 'client_id', 'user_id', 'redirect_uri', 'expires', 'scope', 'id_token', 'code_challenge', 'code_challenge_method'),
             $expires
         );
     }


### PR DESCRIPTION
This is built on https://github.com/bshaffer/oauth2-server-php/pull/951, but missing parts was added:
* Updated Storage classes to support new code_challenge/code_challenge_method fields
* Added support of PKCI even into non-openid Oauth2
* Tested using modified oauth2-demo-php: https://github.com/hkalina/oauth2-demo-php/tree/pkce

Any feedback is welcome!