### PR TITLE
Dont create multiple access tokens when one has not expired yet for e…

### DIFF
--- a/src/OAuth2/ResponseType/AccessToken.php
+++ b/src/OAuth2/ResponseType/AccessToken.php
@@ -100,7 +100,14 @@ class AccessToken implements AccessTokenInterface
             "scope" => $scope
         );
 
-        $this->tokenStorage->setAccessToken($token["access_token"], $client_id, $user_id, $this->config['access_lifetime'] ? time() + $this->config['access_lifetime'] : null, $scope);
+        $response = $this->tokenStorage->setAccessToken($token["access_token"], $client_id, $user_id, $this->config['access_lifetime'] ? time() + $this->config['access_lifetime'] : null, $scope);
+
+        //update token to the existing one for efficiency purposes
+        if(is_array($response)){
+            $token['access_token'] = $response['access_token'];
+            $token['expires_in'] = $response['expires'];
+            $token['scope'] = $response['scope'];
+        }
 
         /*
          * Issue a refresh token also, if we support them

--- a/src/OAuth2/Storage/MongoDB.php
+++ b/src/OAuth2/Storage/MongoDB.php
@@ -129,6 +129,13 @@ class MongoDB implements AuthorizationCodeInterface,
 
     public function setAccessToken($access_token, $client_id, $user_id, $expires, $scope = null)
     {
+
+        //Dont create multiple access tokens when one has not expired yet for efficient purposes and security. Included this to avoid too much of new tokens when one has not expired - Also updated OAuth2\ResponseType\AccessToken to use the existing token that has not expired instead of creating a new one
+        $result = $this->collection('access_token_table')->findOne(array('client_id' => $client_id, 'expires' => ['$gt' => time()]));
+        if(!is_null($result)){
+            return $result;
+        }
+
         // if it exists, update it.
         if ($this->getAccessToken($access_token)) {
             $result = $this->collection('access_token_table')->updateOne(


### PR DESCRIPTION
Dont create multiple access tokens when one has not expired yet for efficient purposes and security. Included this to avoid too much of new tokens creations when one has not expired - Also updated OAuth2\ResponseType\AccessToken to use the existing token that has not expired instead of creating a new one