### PR TITLE
Add support for authorization code grant with PKCE for distributed apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ test/config/test.sqlite
 vendor
 composer.lock
 .idea
+.phpunit.result.cache

--- a/src/OAuth2/GrantType/AuthorizationCode.php
+++ b/src/OAuth2/GrantType/AuthorizationCode.php
@@ -112,7 +112,7 @@ class AuthorizationCode implements GrantTypeInterface
 
                 return FALSE;
             }
-            if ($code_verifier_hashed !== $authCode['code_challenge']) {
+            if (!hash_equals($authCode['code_challenge'], $code_verifier_hashed)) {
                 $response->setError(400, 'code_verifier_mismatch', "The PKCE code verifier parameter does not match the code challenge.");
 
                 return FALSE;

--- a/src/OAuth2/OpenID/Controller/AuthorizeController.php
+++ b/src/OAuth2/OpenID/Controller/AuthorizeController.php
@@ -7,7 +7,7 @@ use OAuth2\RequestInterface;
 use OAuth2\ResponseInterface;
 
 /**
- * @see OAuth2\Controller\AuthorizeControllerInterface
+ * @see \OAuth2\Controller\AuthorizeControllerInterface
  */
 class AuthorizeController extends BaseAuthorizeController implements AuthorizeControllerInterface
 {
@@ -15,16 +15,6 @@ class AuthorizeController extends BaseAuthorizeController implements AuthorizeCo
      * @var mixed
      */
     private $nonce;
-
-    /**
-     * @var mixed
-     */
-    protected $code_challenge;
-
-    /**
-     * @var mixed
-     */
-    protected $code_challenge_method;
 
     /**
      * Set not authorized response
@@ -75,10 +65,6 @@ class AuthorizeController extends BaseAuthorizeController implements AuthorizeCo
         // add the nonce to return with the redirect URI
         $params['nonce'] = $this->nonce;
 
-        // Add PKCE code challenge.
-        $params['code_challenge'] = $this->code_challenge;
-        $params['code_challenge_method'] = $this->code_challenge_method;
-
         return $params;
     }
 
@@ -103,32 +89,6 @@ class AuthorizeController extends BaseAuthorizeController implements AuthorizeCo
         }
 
         $this->nonce = $nonce;
-
-        $code_challenge = $request->query('code_challenge');
-        $code_challenge_method = $request->query('code_challenge_method');
-
-        if ($this->config['enforce_pkce']) {
-            if (!$code_challenge) {
-                $response->setError(400, 'missing_code_challenge', 'This application requires you provide a PKCE code challenge');
-
-                return false;
-            }
-
-            if (preg_match('/^[A-Za-z0-9-._~]{43,128}$/', $code_challenge) !== 1) {
-            $response->setError(400, 'invalid_code_challenge', 'The PKCE code challenge supplied is invalid');
-
-            return false;
-          }
-
-            if (!in_array($code_challenge_method, array('plain', 'S256'), true)) {
-                $response->setError(400, 'missing_code_challenge_method', 'This application requires you specify a PKCE code challenge method');
-
-                return false;
-            }
-        }
-
-        $this->code_challenge = $code_challenge;
-        $this->code_challenge_method = $code_challenge_method;
 
         return true;
     }

--- a/src/OAuth2/Server.php
+++ b/src/OAuth2/Server.php
@@ -173,6 +173,8 @@ class Server implements ResourceControllerInterface,
             'require_exact_redirect_uri' => true,
             'allow_implicit'           => false,
             'enforce_pkce'             => false,
+            'enforce_pkce_for_public_clients' => false,
+            'supported_code_challenge_methods' => array('plain', 'S256'),
             'allow_credentials_in_request_body' => true,
             'allow_public_clients'     => true,
             'always_issue_new_refresh_token' => false,
@@ -578,7 +580,7 @@ class Server implements ResourceControllerInterface,
             }
         }
 
-        $config = array_intersect_key($this->config, array_flip(explode(' ', 'allow_implicit enforce_state require_exact_redirect_uri enforce_pkce')));
+        $config = array_intersect_key($this->config, array_flip(explode(' ', 'allow_implicit enforce_state require_exact_redirect_uri enforce_pkce enforce_pkce_for_public_clients supported_code_challenge_methods')));
 
         if ($this->config['use_openid_connect']) {
             return new OpenIDAuthorizeController($this->storages['client'], $this->responseTypes, $config, $this->getScopeUtil());

--- a/test/config/storage.json
+++ b/test/config/storage.json
@@ -39,11 +39,41 @@
             "redirect_uri": "http://brentertainment.com/voil%C3%A0",
             "expires": "9999999999",
             "id_token": "IDTOKEN"
+        },
+        "testcode-pkce-challenge-plain": {
+            "client_id": "Test Client ID",
+            "user_id": "",
+            "redirect_uri": "",
+            "expires": "9999999999",
+            "id_token": "IDTOKEN",
+            "code_challenge": "testcodechallengetestcodechallengetestcodechallenge",
+            "code_challenge_method": "plain"
+        },
+        "testcode-pkce-challenge-s256": {
+            "client_id": "Test Client ID",
+            "user_id": "",
+            "redirect_uri": "",
+            "expires": "9999999999",
+            "id_token": "IDTOKEN",
+            "code_challenge": "F9mz8u-tLgIAl5bWYGpmI0h1g7C5SAszNM85Ra-kd1E",
+            "code_challenge_method": "S256"
+        },
+        "testcode-pkce-challenge-invalid-method": {
+            "client_id": "Test Client ID",
+            "user_id": "",
+            "redirect_uri": "",
+            "expires": "9999999999",
+            "id_token": "IDTOKEN",
+            "code_challenge": "F9mz8u-tLgIAl5bWYGpmI0h1g7C5SAszNM85Ra-kd1E",
+            "code_challenge_method": "md5"
         }
     },
     "client_credentials" : {
         "Test Client ID": {
             "client_secret": "TestSecret"
+        },
+        "Test Public Client ID": {
+            "is_public": true
         },
         "Test Client ID with Redirect Uri": {
             "client_secret": "TestSecret2",


### PR DESCRIPTION
Add support for "Authorization Code Grant with PKCE" flow to allow distributed apps to securely authenticate with an OAuth server without needing to embed secrets within the distributed application, as these can be easily exposed by decompiling the application binaries.

- Move handlers for code challenge from OIDC AuthorizationController to the base AuthorizationController, so that non-OIDC flows can leverage it as well
- Add mechanism to enforce PKCE code challenges for public clients
- Add mechanism to configure supported code challenge methods
- Change code_verifier comparison to use hash_equals() to avoid timing attacks
- Added tests for all PKCE code challenge flows

Reference:
- [RFC-8252](https://datatracker.ietf.org/doc/html/rfc8252)