### PR TITLE
Fixed type hint of $key param in \OAuth2\Encryption\Jwt::decode()

### DIFF
--- a/src/OAuth2/Encryption/Jwt.php
+++ b/src/OAuth2/Encryption/Jwt.php
@@ -36,7 +36,7 @@ class Jwt implements EncryptionInterface
 
     /**
      * @param string      $jwt
-     * @param null        $key
+     * @param             $key
      * @param array|bool  $allowedAlgorithms
      * @return bool|mixed
      */


### PR DESCRIPTION
The `$key` parameter of the `decode()` method in `\OAuth2\Encryption\Jwt` was type hinted as `null` in the PHPDoc block. 

This was causing errors during static analysis when a string (or any other type) key was passed. 

I removed the `null` type hint and left the type hint empty to match the signature of the `encode()` method in the same class.

Some of these PHPDoc blocks can probably be removed since they should be inherited from the interface.