### PR TITLE
Add explicit null to nullable types for PHP 8.4

### DIFF
--- a/src/OAuth2/ClientAssertionType/HttpBasic.php
+++ b/src/OAuth2/ClientAssertionType/HttpBasic.php
@@ -112,7 +112,7 @@ class HttpBasic implements ClientAssertionTypeInterface
      *
      * @ingroup oauth2_section_2
      */
-    public function getClientCredentials(RequestInterface $request, ResponseInterface $response = null)
+    public function getClientCredentials(RequestInterface $request, ?ResponseInterface $response = null)
     {
         if (!is_null($request->headers('PHP_AUTH_USER')) && !is_null($request->headers('PHP_AUTH_PW'))) {
             return array('client_id' => $request->headers('PHP_AUTH_USER'), 'client_secret' => $request->headers('PHP_AUTH_PW'));

--- a/src/OAuth2/Controller/AuthorizeController.php
+++ b/src/OAuth2/Controller/AuthorizeController.php
@@ -78,7 +78,7 @@ class AuthorizeController implements AuthorizeControllerInterface
      *     );
      * @endcode
      */
-    public function __construct(ClientInterface $clientStorage, array $responseTypes = array(), array $config = array(), ScopeInterface $scopeUtil = null)
+    public function __construct(ClientInterface $clientStorage, array $responseTypes = array(), array $config = array(), ?ScopeInterface $scopeUtil = null)
     {
         $this->clientStorage = $clientStorage;
         $this->responseTypes = $responseTypes;

--- a/src/OAuth2/Controller/ResourceController.php
+++ b/src/OAuth2/Controller/ResourceController.php
@@ -47,7 +47,7 @@ class ResourceController implements ResourceControllerInterface
      * @param array                $config
      * @param ScopeInterface       $scopeUtil
      */
-    public function __construct(TokenTypeInterface $tokenType, AccessTokenInterface $tokenStorage, $config = array(), ScopeInterface $scopeUtil = null)
+    public function __construct(TokenTypeInterface $tokenType, AccessTokenInterface $tokenStorage, $config = array(), ?ScopeInterface $scopeUtil = null)
     {
         $this->tokenType = $tokenType;
         $this->tokenStorage = $tokenStorage;

--- a/src/OAuth2/Controller/TokenController.php
+++ b/src/OAuth2/Controller/TokenController.php
@@ -54,7 +54,7 @@ class TokenController implements TokenControllerInterface
      * @param ScopeInterface               $scopeUtil
      * @throws InvalidArgumentException
      */
-    public function __construct(AccessTokenInterface $accessToken, ClientInterface $clientStorage, array $grantTypes = array(), ClientAssertionTypeInterface $clientAssertionType = null, ScopeInterface $scopeUtil = null)
+    public function __construct(AccessTokenInterface $accessToken, ClientInterface $clientStorage, array $grantTypes = array(), ?ClientAssertionTypeInterface $clientAssertionType = null, ?ScopeInterface $scopeUtil = null)
     {
         if (is_null($clientAssertionType)) {
             foreach ($grantTypes as $grantType) {

--- a/src/OAuth2/GrantType/JwtBearer.php
+++ b/src/OAuth2/GrantType/JwtBearer.php
@@ -37,7 +37,7 @@ class JwtBearer implements GrantTypeInterface, ClientAssertionTypeInterface
      * @param EncryptionInterface|JWT $jwtUtil  - OPTONAL The class used to decode, encode and verify JWTs.
      * @param array                   $config
      */
-    public function __construct(JwtBearerInterface $storage, $audience, EncryptionInterface $jwtUtil = null, array $config = array())
+    public function __construct(JwtBearerInterface $storage, $audience, ?EncryptionInterface $jwtUtil = null, array $config = array())
     {
         $this->storage = $storage;
         $this->audience = $audience;

--- a/src/OAuth2/OpenID/Controller/UserInfoController.php
+++ b/src/OAuth2/OpenID/Controller/UserInfoController.php
@@ -30,7 +30,7 @@ class UserInfoController extends ResourceController implements UserInfoControlle
      * @param array                $config
      * @param ScopeInterface       $scopeUtil
      */
-    public function __construct(TokenTypeInterface $tokenType, AccessTokenInterface $tokenStorage, UserClaimsInterface $userClaimsStorage, $config = array(), ScopeInterface $scopeUtil = null)
+    public function __construct(TokenTypeInterface $tokenType, AccessTokenInterface $tokenStorage, UserClaimsInterface $userClaimsStorage, $config = array(), ?ScopeInterface $scopeUtil = null)
     {
         parent::__construct($tokenType, $tokenStorage, $config, $scopeUtil);
 

--- a/src/OAuth2/OpenID/ResponseType/IdToken.php
+++ b/src/OAuth2/OpenID/ResponseType/IdToken.php
@@ -38,7 +38,7 @@ class IdToken implements IdTokenInterface
      * @param EncryptionInterface $encryptionUtil
      * @throws LogicException
      */
-    public function __construct(UserClaimsInterface $userClaimsStorage, PublicKeyInterface $publicKeyStorage, array $config = array(), EncryptionInterface $encryptionUtil = null)
+    public function __construct(UserClaimsInterface $userClaimsStorage, PublicKeyInterface $publicKeyStorage, array $config = array(), ?EncryptionInterface $encryptionUtil = null)
     {
         $this->userClaimsStorage = $userClaimsStorage;
         $this->publicKeyStorage = $publicKeyStorage;

--- a/src/OAuth2/Request.php
+++ b/src/OAuth2/Request.php
@@ -34,7 +34,7 @@ class Request implements RequestInterface
      *
      * @api
      */
-    public function __construct(array $query = array(), array $request = array(), array $attributes = array(), array $cookies = array(), array $files = array(), array $server = array(), $content = null, array $headers = null)
+    public function __construct(array $query = array(), array $request = array(), array $attributes = array(), array $cookies = array(), array $files = array(), array $server = array(), $content = null, ?array $headers = null)
     {
         $this->initialize($query, $request, $attributes, $cookies, $files, $server, $content, $headers);
     }
@@ -55,7 +55,7 @@ class Request implements RequestInterface
      *
      * @api
      */
-    public function initialize(array $query = array(), array $request = array(), array $attributes = array(), array $cookies = array(), array $files = array(), array $server = array(), $content = null, array $headers = null)
+    public function initialize(array $query = array(), array $request = array(), array $attributes = array(), array $cookies = array(), array $files = array(), array $server = array(), $content = null, ?array $headers = null)
     {
         $this->request = $request;
         $this->query = $query;

--- a/src/OAuth2/ResponseType/AccessToken.php
+++ b/src/OAuth2/ResponseType/AccessToken.php
@@ -38,7 +38,7 @@ class AccessToken implements AccessTokenInterface
      *     );
      * @endcode
      */
-    public function __construct(AccessTokenStorageInterface $tokenStorage, RefreshTokenInterface $refreshStorage = null, array $config = array())
+    public function __construct(AccessTokenStorageInterface $tokenStorage, ?RefreshTokenInterface $refreshStorage = null, array $config = array())
     {
         $this->tokenStorage = $tokenStorage;
         $this->refreshStorage = $refreshStorage;

--- a/src/OAuth2/ResponseType/JwtAccessToken.php
+++ b/src/OAuth2/ResponseType/JwtAccessToken.php
@@ -26,7 +26,7 @@ class JwtAccessToken extends AccessToken
      *                                                        or just the token ID is stored
      * @param EncryptionInterface         $encryptionUtil   -
      */
-    public function __construct(PublicKeyInterface $publicKeyStorage = null, AccessTokenStorageInterface $tokenStorage = null, RefreshTokenInterface $refreshStorage = null, array $config = array(), EncryptionInterface $encryptionUtil = null)
+    public function __construct(?PublicKeyInterface $publicKeyStorage = null, ?AccessTokenStorageInterface $tokenStorage = null, ?RefreshTokenInterface $refreshStorage = null, array $config = array(), ?EncryptionInterface $encryptionUtil = null)
     {
         $this->publicKeyStorage = $publicKeyStorage;
         $config = array_merge(array(

--- a/src/OAuth2/Server.php
+++ b/src/OAuth2/Server.php
@@ -150,7 +150,7 @@ class Server implements ResourceControllerInterface,
      *
      * @ingroup oauth2_section_7
      */
-    public function __construct($storage = array(), array $config = array(), array $grantTypes = array(), array $responseTypes = array(), TokenTypeInterface $tokenType = null, ScopeInterface $scopeUtil = null, ClientAssertionTypeInterface $clientAssertionType = null)
+    public function __construct($storage = array(), array $config = array(), array $grantTypes = array(), array $responseTypes = array(), ?TokenTypeInterface $tokenType = null, ?ScopeInterface $scopeUtil = null, ?ClientAssertionTypeInterface $clientAssertionType = null)
     {
         $storage = is_array($storage) ? $storage : array($storage);
         $this->storages = array();
@@ -289,7 +289,7 @@ class Server implements ResourceControllerInterface,
      *
      * @see http://openid.net/specs/openid-connect-core-1_0.html#UserInfo
      */
-    public function handleUserInfoRequest(RequestInterface $request, ResponseInterface $response = null)
+    public function handleUserInfoRequest(RequestInterface $request, ?ResponseInterface $response = null)
     {
         $this->response = is_null($response) ? new Response() : $response;
         $this->getUserInfoController()->handleUserInfoRequest($request, $this->response);
@@ -315,7 +315,7 @@ class Server implements ResourceControllerInterface,
      *
      * @ingroup oauth2_section_4
      */
-    public function handleTokenRequest(RequestInterface $request, ResponseInterface $response = null)
+    public function handleTokenRequest(RequestInterface $request, ?ResponseInterface $response = null)
     {
         $this->response = is_null($response) ? new Response() : $response;
         $this->getTokenController()->handleTokenRequest($request, $this->response);
@@ -328,7 +328,7 @@ class Server implements ResourceControllerInterface,
      * @param ResponseInterface $response - Response object
      * @return mixed
      */
-    public function grantAccessToken(RequestInterface $request, ResponseInterface $response = null)
+    public function grantAccessToken(RequestInterface $request, ?ResponseInterface $response = null)
     {
         $this->response = is_null($response) ? new Response() : $response;
         $value = $this->getTokenController()->grantAccessToken($request, $this->response);
@@ -346,7 +346,7 @@ class Server implements ResourceControllerInterface,
      * @param ResponseInterface $response
      * @return Response|ResponseInterface
      */
-    public function handleRevokeRequest(RequestInterface $request, ResponseInterface $response = null)
+    public function handleRevokeRequest(RequestInterface $request, ?ResponseInterface $response = null)
     {
         $this->response = is_null($response) ? new Response() : $response;
         $this->getTokenController()->handleRevokeRequest($request, $this->response);
@@ -408,7 +408,7 @@ class Server implements ResourceControllerInterface,
      *
      * @ingroup oauth2_section_3
      */
-    public function validateAuthorizeRequest(RequestInterface $request, ResponseInterface $response = null)
+    public function validateAuthorizeRequest(RequestInterface $request, ?ResponseInterface $response = null)
     {
         $this->response = is_null($response) ? new Response() : $response;
         $value = $this->getAuthorizeController()->validateAuthorizeRequest($request, $this->response);
@@ -422,7 +422,7 @@ class Server implements ResourceControllerInterface,
      * @param string            $scope    - Scope
      * @return mixed
      */
-    public function verifyResourceRequest(RequestInterface $request, ResponseInterface $response = null, $scope = null)
+    public function verifyResourceRequest(RequestInterface $request, ?ResponseInterface $response = null, $scope = null)
     {
         $this->response = is_null($response) ? new Response() : $response;
         $value = $this->getResourceController()->verifyResourceRequest($request, $this->response, $scope);
@@ -435,7 +435,7 @@ class Server implements ResourceControllerInterface,
      * @param ResponseInterface $response - Response object
      * @return mixed
      */
-    public function getAccessTokenData(RequestInterface $request, ResponseInterface $response = null)
+    public function getAccessTokenData(RequestInterface $request, ?ResponseInterface $response = null)
     {
         $this->response = is_null($response) ? new Response() : $response;
         $value = $this->getResourceController()->getAccessTokenData($request, $this->response);

--- a/src/OAuth2/Storage/JwtAccessToken.php
+++ b/src/OAuth2/Storage/JwtAccessToken.php
@@ -21,7 +21,7 @@ class JwtAccessToken implements JwtAccessTokenInterface
      *                                                                is not necessary when using this grant type.
      * @param OAuth2\Encryption\EncryptionInterface $encryptionUtil   OPTIONAL class to use for "encode" and "decode" functions.
      */
-    public function __construct(PublicKeyInterface $publicKeyStorage, AccessTokenInterface $tokenStorage = null, EncryptionInterface $encryptionUtil = null)
+    public function __construct(PublicKeyInterface $publicKeyStorage, ?AccessTokenInterface $tokenStorage = null, ?EncryptionInterface $encryptionUtil = null)
     {
         $this->publicKeyStorage = $publicKeyStorage;
         $this->tokenStorage = $tokenStorage;


### PR DESCRIPTION
Minimal fix for #1073.  Adds the explicit `?` to implicitly nullable arguments within the `src` tree.